### PR TITLE
Add --metadata-key to simplify getting one metadata value

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Options:
   -i <input.fw> Specify the input firmware update file (Use - for stdin)
   -l, --list   List the available tasks in a firmware update
   -m, --metadata   Print metadata in the firmware update
+  --metadata-key <key> Only output the specified key's value when printing metadata
   -n   Report numeric progress
   -o <output.fw> Specify the output file when creating an update (Use - for stdout)
   -p, --public-key-file <keyfile> A public key file for verifying firmware updates

--- a/src/fwup.c
+++ b/src/fwup.c
@@ -96,6 +96,7 @@ static void print_usage()
     printf("  -i <input.fw> Specify the input firmware update file (Use - for stdin)\n");
     printf("  -l, --list   List the available tasks in a firmware update\n");
     printf("  -m, --metadata   Print metadata in the firmware update\n");
+    printf("  --metadata-key <key> Only output the specified key's value when printing metadata\n");
     printf("  -n   Report numeric progress\n");
     printf("  -o <output.fw> Specify the output file when creating an update (Use - for stdout)\n");
     printf("  -p, --public-key-file <keyfile> A public key file for verifying firmware updates (can specify multiple times)\n");
@@ -168,6 +169,7 @@ enum fwup_long_option_only_value {
     OPTION_NO_EJECT = 0x1000,
     OPTION_ENABLE_TRIM,
     OPTION_EXIT_HANDSHAKE,
+    OPTION_METADATA_KEY,
     OPTION_PRIVATE_KEY,
     OPTION_PUBLIC_KEY,
     OPTION_PROGRESS_LOW,
@@ -191,6 +193,7 @@ static struct option long_options[] = {
     {"framing",  no_argument,       0, 'F'},
     {"gen-keys", no_argument,       0, 'g'},
     {"help",     no_argument,       0, 'h'},
+    {"metadata-key", required_argument, 0, OPTION_METADATA_KEY},
     {"list",     no_argument,       0, 'l'},
     {"metadata", no_argument,       0, 'm'},
     {"private-key", required_argument, 0, OPTION_PRIVATE_KEY},
@@ -383,6 +386,7 @@ int main(int argc, char **argv)
     unsigned char *signing_key = NULL;
     unsigned char *public_keys[FWUP_MAX_PUBLIC_KEYS + 1] = {NULL};
     int num_public_keys = 0;
+    const char *metadata_key = NULL;
 #if __APPLE__
     // On hosts, the right behavior for almost all use cases is to eject
     // so that the user can plug the SDCard into their board. Detecting
@@ -490,6 +494,9 @@ int main(int argc, char **argv)
         case 'm': // --metadata
             command = CMD_METADATA;
             easy_mode = false;
+            break;
+        case OPTION_METADATA_KEY: // --metadata-key
+            metadata_key = optarg;
             break;
         case 'o':
             output_filename = optarg;
@@ -759,7 +766,7 @@ int main(int argc, char **argv)
         break;
 
     case CMD_METADATA:
-        if (fwup_metadata(input_filename, public_keys) < 0)
+        if (fwup_metadata(input_filename, public_keys, metadata_key) < 0)
             fwup_errx(EXIT_FAILURE, "%s", last_error());
 
         break;

--- a/src/fwup_metadata.c
+++ b/src/fwup_metadata.c
@@ -46,9 +46,12 @@ static void list_metadata(cfg_t *cfg, struct simple_string *s)
  * @brief Dump the metadata in a firmware update file
  * @param fw_filename the firmware update filename
  * @param public_keys a list of public keys
+ * @param metadata_key if non-NULL, then print the value of the specified key
  * @return 0 if successful
  */
-int fwup_metadata(const char *fw_filename, unsigned char * const *public_keys)
+int fwup_metadata(const char *fw_filename,
+                  unsigned char * const *public_keys,
+                  const char *metadata_key)
 {
     cfg_t *cfg;
     if (cfgfile_parse_fw_meta_conf(fw_filename, &cfg, public_keys) < 0)
@@ -56,7 +59,13 @@ int fwup_metadata(const char *fw_filename, unsigned char * const *public_keys)
 
     struct simple_string s;
     simple_string_init(&s);
-    list_metadata(cfg, &s);
+
+    if (metadata_key) {
+        ssprintf(&s, "%s\n", cfg_opt_getnstr(cfg_getopt(cfg, metadata_key), 0));
+    } else {
+        list_metadata(cfg, &s);
+    }
+
     cfgfile_free(cfg);
 
     fwup_output(FRAMING_TYPE_SUCCESS, 0, s.str);

--- a/src/fwup_metadata.h
+++ b/src/fwup_metadata.h
@@ -17,6 +17,6 @@
 #ifndef FWUP_METADATA_H
 #define FWUP_METADATA_H
 
-int fwup_metadata(const char *fw_filename, unsigned char * const *public_keys);
+int fwup_metadata(const char *fw_filename, unsigned char * const *public_keys, const char *metadata_key);
 
 #endif // FWUP_METADATA_H

--- a/tests/190_one_metadata_cmdline.test
+++ b/tests/190_one_metadata_cmdline.test
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+#
+# Test that metadata can be retrieved from the commandline one by one
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+EXPECTED_OUTPUT=$WORK/expected_output
+ACTUAL_OUTPUT=$WORK/actual_output
+
+cat >$CONFIG <<EOF
+meta-product = "product name"
+meta-description = "product description"
+meta-version = "some version"
+meta-platform = "a platform"
+meta-architecture = "an architecture"
+meta-author = "someone"
+EOF
+
+cat >$EXPECTED_OUTPUT.product <<EOF
+product name
+EOF
+cat >$EXPECTED_OUTPUT.description <<EOF
+product description
+EOF
+cat >$EXPECTED_OUTPUT.version <<EOF
+some version
+EOF
+cat >$EXPECTED_OUTPUT.author <<EOF
+someone
+EOF
+cat >$EXPECTED_OUTPUT.platform <<EOF
+a platform
+EOF
+cat >$EXPECTED_OUTPUT.architecture <<EOF
+an architecture
+EOF
+cat >$EXPECTED_OUTPUT.creation_date <<EOF
+2018-05-05T18:10:16Z
+EOF
+cat >$EXPECTED_OUTPUT.uuid <<EOF
+ded51581-3c37-5dd5-d1b6-cd8503e4cfc4
+EOF
+cat >$EXPECTED_OUTPUT.unknown <<EOF
+(null)
+EOF
+
+# Create the test archive
+SOURCE_DATE_EPOCH=1525543816 $FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Test every key that should work
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-product> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.product $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-description> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.description $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-version> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.version $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-author> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.author $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-platform> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.platform $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-architecture> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.architecture $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-creation-date> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.creation_date $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key meta-uuid> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.uuid $ACTUAL_OUTPUT
+
+# Test keys that shouldn't work
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key bad-key> $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.unknown $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key 1 > $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.unknown $ACTUAL_OUTPUT
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m --metadata-key "" > $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT.unknown $ACTUAL_OUTPUT
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE


### PR DESCRIPTION
Even though it's possible to use sed and awk to grab the metadata items
you want in shell scripts, it's annoying to do this and unescape quotes,
etc. This change adds the `--metadata-key` option. Here's an example:

```sh
$ fwup -m -i fwup.fw --metadata-key meta-uuid
ded51581-3c37-5dd5-d1b6-cd8503e4cfc4
```
