### PR TITLE
Improve progress reporting for u-boot operations

### DIFF
--- a/src/uboot_env.c
+++ b/src/uboot_env.c
@@ -55,6 +55,18 @@ int uboot_env_verify_cfg(cfg_t *cfg)
     return 0;
 }
 
+int uboot_env_block_count(cfg_t *cfg)
+{
+    // This assumes a valid configuration as checked by uboot_env_verify_cfg.
+    int block_count = cfg_getint(cfg, "block-count");
+
+    int block_offset_redund = cfg_getint(cfg, "block-offset-redund");
+    if (block_offset_redund >= 0)
+        block_count = block_count * 2;
+
+    return block_count;
+}
+
 int uboot_env_create_cfg(cfg_t *cfg, struct uboot_env *output)
 {
     memset(output, 0, sizeof(struct uboot_env));

--- a/src/uboot_env.h
+++ b/src/uboot_env.h
@@ -46,6 +46,7 @@ struct uboot_env {
 };
 
 int uboot_env_verify_cfg(cfg_t *cfg);
+int uboot_env_block_count(cfg_t *cfg);
 int uboot_env_create_cfg(cfg_t *cfg, struct uboot_env *output);
 
 int uboot_env_setenv(struct uboot_env *env, const char *name, const char *value);

--- a/tests/124_uboot_bad_param.test
+++ b/tests/124_uboot_bad_param.test
@@ -6,6 +6,7 @@
 
 . "$(cd "$(dirname "$0")" && pwd)/common.sh"
 
+# Bad block count
 cat >$CONFIG <<EOF
 uboot-environment uboot-env {
     block-offset = 0
@@ -18,8 +19,45 @@ task complete {
     }
 }
 EOF
+if $FWUP_CREATE -c -f $CONFIG -o $FWFILE; then
+    echo "Expected this to fail?"
+    exit 1
+fi
 
-# Create the firmware file, then "burn it"
+# Missing U-Boot environment - uboot_clearenv
+cat >$CONFIG <<EOF
+task complete {
+    on-finish {
+       uboot_clearenv(uboot-env)
+    }
+}
+EOF
+if $FWUP_CREATE -c -f $CONFIG -o $FWFILE; then
+    echo "Expected this to fail?"
+    exit 1
+fi
+
+# Missing U-Boot environment - uboot_setenv
+cat >$CONFIG <<EOF
+task complete {
+    on-finish {
+       uboot_setenv(uboot-env, "var1", 2000)
+    }
+}
+EOF
+if $FWUP_CREATE -c -f $CONFIG -o $FWFILE; then
+    echo "Expected this to fail?"
+    exit 1
+fi
+
+# Missing U-Boot environment - uboot_unsetenv
+cat >$CONFIG <<EOF
+task complete {
+    on-finish {
+       uboot_unsetenv(uboot-env, "var1")
+    }
+}
+EOF
 if $FWUP_CREATE -c -f $CONFIG -o $FWFILE; then
     echo "Expected this to fail?"
     exit 1


### PR DESCRIPTION
Previously each U-Boot operation counted as 512 bytes. Now they count as
the full environment block. Even though byte count reports are arbitrary
due to caching, this fixes some weirdness with seeing 128KB U-Boot
environment block operations get reported as surprisingly small.

This also reduces some duplication of code and adds a few more tests to
make sure that a common mistake is reported nicely.
