### PR TITLE
Allow specifying a fallback task

### DIFF
--- a/src/fwup.c
+++ b/src/fwup.c
@@ -110,6 +110,7 @@ static void print_usage()
     printf("  --sparse-check <path> Check if the OS and file system supports sparse files at path\n");
     printf("  --sparse-check-size <bytes> Hole size to check for --sparse-check\n");
     printf("  -t, --task <task> Task to apply within the firmware update\n");
+    printf("  -T, --fallback-task <task> Fallback task to apply within the firmware update if the first task fails\n");
     printf("  -u, --unmount Unmount all partitions on device first\n");
     printf("  -U, --no-unmount Do not try to unmount partitions on device\n");
     printf("  --unsafe Allow unsafe commands (consider applying only signed archives)\n");
@@ -207,6 +208,7 @@ static struct option long_options[] = {
     {"sparse-check-size", required_argument, 0, OPTION_SPARSE_CHECK_SIZE},
     {"sign",     no_argument,       0, 'S'},
     {"task",     required_argument, 0, 't'},
+    {"fallback-task", required_argument, 0, 'T'},
     {"unmount",  no_argument,       0, 'u'},
     {"no-unmount", no_argument,     0, 'U'},
     {"unsafe",   no_argument,       0, OPTION_UNSAFE},
@@ -376,6 +378,7 @@ int main(int argc, char **argv)
     const char *input_filename = NULL;
     const char *output_filename = NULL;
     const char *task = NULL;
+    const char *fallback_task = NULL;
 #ifndef FWUP_MINIMAL
     const char *configfile = "fwupdate.conf";
     const char *sparse_check = NULL;
@@ -413,7 +416,7 @@ int main(int argc, char **argv)
     atexit(mmc_finalize);
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "acd:DEf:Fghi:lmno:p:qSs:t:VvUuyZz123456789", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "acd:DEf:Fghi:lmno:p:qSs:t:T:VvUuyZz123456789", long_options, NULL)) != -1) {
         switch (opt) {
         case 'a': // --apply
             command = CMD_APPLY;
@@ -519,6 +522,9 @@ int main(int argc, char **argv)
             break;
         case 't': // --task
             task = optarg;
+            break;
+        case 'T': // --fallback-task
+            fallback_task = optarg;
             break;
         case 'v': // --verbose
             fwup_verbose = true;
@@ -713,6 +719,7 @@ int main(int argc, char **argv)
 
         if (fwup_apply(input_filename,
                        task,
+                       fallback_task,
                        output_fd,
                        end_offset,
                        &progress,

--- a/src/fwup_apply.h
+++ b/src/fwup_apply.h
@@ -23,6 +23,7 @@ struct fwup_progress;
 
 int fwup_apply(const char *fw_filename,
                const char *task,
+               const char *fb_task,
                int output_fd,
                off_t end_offset,
                struct fwup_progress *progress,

--- a/tests/192_fallback_task.test
+++ b/tests/192_fallback_task.test
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+#
+# Test the fallback task ability when initial task fails
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+        host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+	on-resource TEST { raw_write(0) }
+}
+EOF
+
+cat >$EXPECTED_META_CONF <<EOF
+file-resource "TEST" {
+length=1024
+blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+task "complete" {
+on-resource "TEST" {
+funlist = {"2", "raw_write", "0"}
+}
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Check that the zip file was created as expected
+check_meta_conf
+cmp $TESTFILE_1K $UNZIPDIR/data/TEST
+
+# The upgrade task does not exist, so it should fallback to the complete task
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t upgrade -T complete --verify-writes
+cmp_bytes 1024 $IMGFILE $TESTFILE_1K
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -191,6 +191,7 @@ TESTS = 001_simple_fw.test \
 	188_uboot_redundant_bad_param.test \
 	189_uboot_redundant_recover.test \
 	190_one_metadata_cmdline.test \
-	191_disk_crypto_via_env.test
+	191_disk_crypto_via_env.test \
+	192_fallback_test.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
In very specific cases, it might be desirable to fallback to another
task when the target task fails. Most commonly this will be falling
back to the `complete` task when the `upgrade` fails due to the firmware
not having a previous firmware.

The fallback will only occur if the failure is withing the tasks functions
so checks before and after the task do not trigger a fallback (i.e. issues
with archive or config file)

This is inspired by nerves-project/nerves#682