### PR TITLE
Remove linux/fs.h include

### DIFF
--- a/src/mmc_linux.c
+++ b/src/mmc_linux.c
@@ -35,7 +35,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <linux/fs.h>
 #include <linux/major.h>
 
 #ifndef BLKDISCARD


### PR DESCRIPTION
This header file doesn't appear to be needed. This also fixes a build
error with glibc 2.36.

See
https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
for more information about the issue.

Fixes #192
