### PR TITLE
Support multiple tasks in `--task`

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -49,6 +49,9 @@ struct fun_context {
     // Task configuration
     cfg_t *task;
 
+    // Lists of task configurations
+    cfg_t *tasks[16];
+
     // When processing events (on-init, on-resource, on-finish, etc.) this is that configuration
     cfg_t *on_event;
 

--- a/tests/192_multiple_tasks.test
+++ b/tests/192_multiple_tasks.test
@@ -1,0 +1,42 @@
+#/bin/sh
+
+#
+# Test that multiple tasks are attempted until success with a task list
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+        host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+on-resource TEST { raw_write(0) }
+}
+EOF
+
+cat >$EXPECTED_META_CONF <<EOF
+file-resource "TEST" {
+length=1024
+blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+task "complete" {
+on-resource "TEST" {
+funlist = {"2", "raw_write", "0"}
+}
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Check that the zip file was created as expected
+check_meta_conf
+cmp $TESTFILE_1K $UNZIPDIR/data/TEST
+
+# The upgrade task does not exist, so it should fallback to the complete task
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t upgrade:complete
+cmp_bytes 1024 $IMGFILE $TESTFILE_1K
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -191,6 +191,7 @@ TESTS = 001_simple_fw.test \
 	188_uboot_redundant_bad_param.test \
 	189_uboot_redundant_recover.test \
 	190_one_metadata_cmdline.test \
-	191_disk_crypto_via_env.test
+	191_disk_crypto_via_env.test \
+	192_multiple_tasks.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
Based on the discussion in #185

The idea is that you can specify a list of tasks with `-t` and fwup will try each one until the first success supporting a "fallback" behavior.

This isn't quite working, but pushing up draft for now so someone smarter than me may see why while I'm figuring it out. It seems to work for one task still, but specifying `task1:task2` breaks when `task1` does not exist. It seems my check of trying to avoid a non-existent task is not working