### PR TITLE
Handle out of bounds reads by xdelta

### DIFF
--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -247,8 +247,12 @@ static int xdelta_read_source_callback(void *cookie, void *buf, size_t count, of
     struct fun_context *fctx = (struct fun_context *) cookie;
 
     if (offset < 0 ||
-        offset + count > fctx->xd_source_count)
+        offset > fctx->xd_source_count)
         ERR_RETURN("xdelta tried to load outside of allowed byte range (0-%" PRId64 "): offset: %" PRId64 ", count: %d", fctx->xd_source_count, offset, count);
+
+    if (count > fctx->xd_source_count ||
+        offset > fctx->xd_source_count - count)
+        count = fctx->xd_source_count - offset;
 
     return block_cache_pread(fctx->output, buf, count, fctx->xd_source_offset + offset);
 }

--- a/src/fwup_xdelta3.c
+++ b/src/fwup_xdelta3.c
@@ -68,10 +68,10 @@ static int xdelta_read_source_block(struct xdelta_state *xd, xoff_t blkno)
                               (void *) xd->source.curblk,
                               xd->source.blksize,
                               xd->source.blksize * blkno);
-    if (rc)
+    if (rc < 0)
         return -1;
 
-    xd->source.onblk = xd->source.blksize;
+    xd->source.onblk = rc;
     xd->source.curblkno = blkno;
 
     return 1;

--- a/tests/192_delta_out_of_bound.test
+++ b/tests/192_delta_out_of_bound.test
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+#
+# Verify xdelta out of bounds read
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+FWFILE2="$WORK/fwup2.fw"
+
+cat >"$CONFIG" <<EOF
+define(ROOTFS_A_PART_OFFSET, 1024)
+define(ROOTFS_A_PART_COUNT, 1024)
+define(ROOTFS_B_PART_OFFSET, 2048)
+define(ROOTFS_B_PART_COUNT, 1024)
+
+file-resource rootfs.original {
+        host-path = "${TESTFILE_1K}"
+}
+file-resource rootfs.next {
+        host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+    on-resource rootfs.original { raw_write(\${ROOTFS_A_PART_OFFSET}) }
+}
+task upgrade {
+    on-resource rootfs.next {
+        delta-source-raw-offset=\${ROOTFS_A_PART_OFFSET}
+        delta-source-raw-count=2 # 1K
+        raw_write(\${ROOTFS_B_PART_OFFSET})
+    }
+}
+EOF
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f "$CONFIG" -o "$FWFILE"
+$FWUP_APPLY -a -d "$IMGFILE" -i "$FWFILE" -t complete
+
+# Check that the resources got copied to all of the right places
+cmp_bytes 1024 "$TESTFILE_1K" "$IMGFILE" 0 524288
+
+# Manually create the delta upgrade by replacing rootfs.next
+# with the delta3 version
+mkdir -p "$WORK/data"
+xdelta3 -A -S -f -s "$TESTFILE_1K" "$TESTFILE_1K" "$WORK/data/rootfs.next"
+cp "$FWFILE" "$FWFILE2"
+(cd "$WORK" && zip "$FWFILE2" data/rootfs.next)
+
+# NOTE: use "unzip -v $FWFILE2" to verify archive contents
+
+# Now upgrade the IMGFILE file
+$FWUP_APPLY -a -d "$IMGFILE" -i "$FWFILE2" -t upgrade
+
+cmp_bytes 1024 "$TESTFILE_1K" "$IMGFILE" 0 524288  # Same
+cmp_bytes 1024 "$TESTFILE_1K" "$IMGFILE" 0 1048576 # Updated
+
+# Check that the firmware metadata didn't change (including the UUID)
+$FWUP_APPLY_NO_CHECK -m -i "$FWFILE" > "$WORK/original.metadata"
+$FWUP_APPLY_NO_CHECK -m -i "$FWFILE2" > "$WORK/delta_update.metadata"
+diff "$WORK/original.metadata" "$WORK/delta_update.metadata"
+
+# Check that the verify logic works on both files
+$FWUP_VERIFY -V -i "$FWFILE"
+$FWUP_VERIFY -V -i "$FWFILE2"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -191,6 +191,7 @@ TESTS = 001_simple_fw.test \
 	188_uboot_redundant_bad_param.test \
 	189_uboot_redundant_recover.test \
 	190_one_metadata_cmdline.test \
-	191_disk_crypto_via_env.test
+	191_disk_crypto_via_env.test \
+	192_delta_out_of_bound.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
Following the discussion here https://github.com/fwup-home/fwup/issues/198.

This PR handles out of bounds reads at most the available left bytes.