### PR TITLE
Allow /dev/null to be specified when no device is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ fat_touch(block_offset, filename)       | 0.7.0 | Create an empty file if the fi
 gpt_write(gpt)                          | 1.4.0 | Write the specified GPT to the target
 info(message)                           | 0.13.0 | Print out an informational message
 mbr_write(mbr)                          | 0.1.0 | Write the specified mbr to the target
-path_write(destination_path)            | 0.16.0 | Write a resource to a path on the host. Requires the `--unsafe` flag
+path_write(destination_path)            | 0.16.0 | Write a resource to a path on the host. Requires the `--unsafe` flag. Passing `-d /dev/null` works if no destination image.
 pipe_write(command)                     | 0.16.0 | Pipe a resource through a command on the host. Requires the `--unsafe` flag
 raw_memset(block_offset, block_count, value) | 0.10.0 | Write the specified byte value repeatedly for the specified blocks
 raw_write(block_offset, options)        | 0.1.0 | Write the resource to the specified block offset. Options include `cipher` and `secret`.

--- a/src/fwup.c
+++ b/src/fwup.c
@@ -668,6 +668,9 @@ int main(int argc, char **argv)
                 fwup_warnx("ignoring --enable_trim since operating on a regular file");
                 enable_trim = false;
             }
+        } else if (is_device_null(mmc_device_path)) {
+            output_fd = open(mmc_device_path, O_WRONLY);
+            verify_writes = 0;
         } else {
             // Attempt to unmount everything using the device to avoid corrupting partitions.
             // For partial updates, this just unmounts everything that can be unmounted. Errors

--- a/src/util.c
+++ b/src/util.c
@@ -283,6 +283,19 @@ bool will_be_regular_file(const char *path)
 }
 
 /**
+ * Return true if the file is the special null device.
+ */
+bool is_device_null(const char *path)
+{
+#ifdef _WIN32
+    // NUL not supported on Windows
+    return false;
+#else
+    return strcmp(path, "/dev/null") == 0;
+#endif
+}
+
+/**
  * Return true if the file exists.
  */
 bool file_exists(const char *path)

--- a/src/util.h
+++ b/src/util.h
@@ -47,6 +47,7 @@ int archive_filename_to_resource(const char *name, char *result, size_t maxlengt
 bool will_be_regular_file(const char *path);
 bool file_exists(const char *path);
 bool is_regular_file(const char *path);
+bool is_device_null(const char *path);
 
 #define NUM_ELEMENTS(X) (sizeof(X) / sizeof(X[0]))
 

--- a/tests/133_path_write_file.test
+++ b/tests/133_path_write_file.test
@@ -9,7 +9,7 @@
 OUTFILE1=$WORK/output1k
 OUTFILE2=$WORK/output1k_2
 
-cat >$CONFIG <<EOF
+cat >"$CONFIG" <<EOF
 file-resource TEST1 {
 	host-path = "${TESTFILE_1K}"
 }
@@ -26,22 +26,35 @@ task bad_file {
 EOF
 
 # Create the firmware file like normal
-$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_CREATE -c -f "$CONFIG" -o "$FWFILE"
 
-if $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete; then
+if $FWUP_APPLY -a -d "$IMGFILE" -i "$FWFILE" -t complete; then
     echo "No --unsafe:  The path_write should have failed."
     exit 1
 fi
 
 # Try applying the update
-$FWUP_APPLY --unsafe -a -d $IMGFILE -i $FWFILE -t complete
+rm -f "$OUTFILE1" "$OUTFILE2"
+$FWUP_APPLY --unsafe -a -d "$IMGFILE" -i "$FWFILE" -t complete
 
 # Check that the files were updated
-cmp $TESTFILE_1K $OUTFILE1
-cmp $TESTFILE_150K $OUTFILE2
+cmp "$TESTFILE_1K" "$OUTFILE1"
+cmp "$TESTFILE_150K" "$OUTFILE2"
+
+# Try again, but specify /dev/null since that's a thing that people do
+# with firmware updates that are just use path_write.
+if [ "$CC" != "x86_64-w64-mingw32-gcc" -a "$MODE" != "windows" ]; then
+    # /dev/null only support on non-Windows platforms
+    rm -f "$OUTFILE1" "$OUTFILE2"
+    $FWUP_APPLY_NO_CHECK --unsafe -a -d /dev/null -i "$FWFILE" -t complete
+
+    # Check that the files were updated
+    cmp "$TESTFILE_1K" "$OUTFILE1"
+    cmp "$TESTFILE_150K" "$OUTFILE2"
+fi
 
 # Try applying the update to a directory (should fail)
-if $FWUP_APPLY --unsafe -a -d $IMGFILE -i $FWFILE -t bad_file; then
+if $FWUP_APPLY --unsafe -a -d "$IMGFILE" -i "$FWFILE" -t bad_file; then
     echo "Expected path_write to an existing directory to fail."
     exit 1
 fi

--- a/tests/134_pipe_write_file.test
+++ b/tests/134_pipe_write_file.test
@@ -15,7 +15,7 @@ if [ "$CC" = "x86_64-w64-mingw32-gcc" -o "$MODE" = "windows" ]; then
     exit 77
 fi
 
-cat >$CONFIG <<EOF
+cat >"$CONFIG" <<EOF
 file-resource TEST {
 	host-path = "${TESTFILE_1K}"
 }
@@ -34,26 +34,33 @@ task short_command {
 EOF
 
 # Create the firmware file like normal
-$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_CREATE -c -f "$CONFIG" -o "$FWFILE"
 
 # Check that pipe_write fails w/o --unsafe
-if $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete; then
+if $FWUP_APPLY -a -d "$IMGFILE" -i "$FWFILE" -t complete; then
     echo "No --unsafe:  The pipe_write should have failed."
     exit 1
 fi
 
 # Pipe the contents of the firmware file through fwup
-$FWUP_APPLY --unsafe -a -d $IMGFILE -i $FWFILE -t complete
-cmp $TESTFILE_1K $OUTFILE
+rm -f "$OUTFILE"
+$FWUP_APPLY --unsafe -a -d "$IMGFILE" -i "$FWFILE" -t complete
+cmp "$TESTFILE_1K" "$OUTFILE"
+
+# Try it again, but use /dev/null since that's a thing people do with pipe_write
+# (This whole test doesn't run on Windows, so Windows check for /dev/null isn't necessary)
+rm -f "$OUTFILE"
+$FWUP_APPLY_NO_CHECK --unsafe -a -d /dev/null -i "$FWFILE" -t complete
+cmp "$TESTFILE_1K" "$OUTFILE"
 
 # Try applying the update to a bogus command (should fail)
-if $FWUP_APPLY --unsafe -a -d $IMGFILE -i $FWFILE -t bad_command; then
+if $FWUP_APPLY --unsafe -a -d "$IMGFILE" -i "$FWFILE" -t bad_command; then
     echo "Expected pipe_write to fail when invoking an unknown command."
     exit 1
 fi
 
 # Try applying the update to a failing command (should fail)
-if $FWUP_APPLY --unsafe -a -d $IMGFILE -i $FWFILE -t failing_command; then
+if $FWUP_APPLY --unsafe -a -d "$IMGFILE" -i "$FWFILE" -t failing_command; then
     echo "Expected pipe_write to fail when the command failed."
     exit 1
 fi


### PR DESCRIPTION
When exclusively using path_write and pipe_write, there's no need for a
destination image. Fwup really expects one so to tell it that you really
don't want one, pass `-d /dev/null`.

Fixes https://github.com/fwup-home/fwup/issues/200. See the issue for
more discussion.

Thanks to Edoardo Rossi for raising the need and also for supply the
patch to add it.
