### PR TITLE
Fix FAT corruption test to actually corrupt the table

### DIFF
--- a/tests/179_verify_detects_raw_corruption.test
+++ b/tests/179_verify_detects_raw_corruption.test
@@ -29,27 +29,34 @@ $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-verify-writes
 
 # Check that corruption is various places is detected
+rm "$IMGFILE"
 if WRITE_SHIM_CORRUPT_OFFSET=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected MBR corruption to be detected."
     exit 1
 fi
 
+rm "$IMGFILE"
 if WRITE_SHIM_CORRUPT_OFFSET=512 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected MBR corruption to be detected."
     exit 1
 fi
 
+rm "$IMGFILE"
 if WRITE_SHIM_CORRUPT_OFFSET=1023 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected MBR corruption to be detected."
     exit 1
 fi
 
 # Check that corruption isn't detected when verify-writes is off.
+rm "$IMGFILE"
 WRITE_SHIM_CORRUPT_OFFSET=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-verify-writes
+rm "$IMGFILE"
 WRITE_SHIM_CORRUPT_OFFSET=512 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-verify-writes
+rm "$IMGFILE"
 WRITE_SHIM_CORRUPT_OFFSET=1023 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-verify-writes
 
 # Check that default for regular files is off. I.e., this next line will pass.
+rm "$IMGFILE"
 WRITE_SHIM_CORRUPT_OFFSET=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
 
 # Check that the verify logic works on this file

--- a/tests/180_verify_detects_fat_corruption.test
+++ b/tests/180_verify_detects_fat_corruption.test
@@ -55,8 +55,8 @@ if WRITE_SHIM_CORRUPT_OFFSET=32256 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t comp
     exit 1
 fi
 
-# Corrupt boot partition in FAT block that's beyond 128KB (256 * 1024)
-if WRITE_SHIM_CORRUPT_OFFSET=131072 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
+# Corrupt boot partition in FAT block that's beyond 256KB (512 * 512)
+if WRITE_SHIM_CORRUPT_OFFSET=262144 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected FAT header corruption to be detected."
     exit 1
 fi

--- a/tests/180_verify_detects_fat_corruption.test
+++ b/tests/180_verify_detects_fat_corruption.test
@@ -39,23 +39,27 @@ $FWUP_CREATE -c -f $CONFIG -o $FWFILE
 
 # Sanity check that there are no issues normally
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes
+rm "$IMGFILE"
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-verify-writes
 
 # Check that corruption is various places is detected
 
 # Corrupt MBR
+rm "$IMGFILE"
 if WRITE_SHIM_CORRUPT_OFFSET=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected MBR corruption to be detected."
     exit 1
 fi
 
 # Corrupt boot partition (63 * 512)
+rm "$IMGFILE"
 if WRITE_SHIM_CORRUPT_OFFSET=32256 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected FAT header corruption to be detected."
     exit 1
 fi
 
 # Corrupt boot partition in FAT block that's beyond 256KB (512 * 512)
+rm "$IMGFILE"
 if WRITE_SHIM_CORRUPT_OFFSET=262144 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes; then
     echo "Expected FAT header corruption to be detected."
     exit 1


### PR DESCRIPTION
It turned out that the bit being flipped was in a big block of zeros. It
probably doesn't make a difference for the point of the test, but
putting it in a real data block seems better.
