### PR TITLE
Use resource name when fat_write's filename isn't specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ error(message)                          | 0.12.0 | Immediately fail a firmware u
 execute(command)                        | 0.16.0 | Execute a command on the host. Requires the `--unsafe` flag
 fat_mkfs(block_offset, block_count)     | 0.1.0 | Create a FAT file system at the specified block offset and count
 fat_write(block_offset, filename)       | 0.1.0 | Write the resource to the FAT file system at the specified block offset
+fat_write(block_offset)                 | 1.10.0 | Same as the two argument fat_write except the filename is the resource name. This is handled when creating the archive, so it's backwards compatible.
 fat_attrib(block_offset, filename, attrib) | 0.1.0 | Modify a file's attributes. attrib is a string like "RHS" where R=readonly, H=hidden, S=system
 fat_mv(block_offset, oldname, newname)  | 0.1.0 | Rename the specified file on a FAT file system
 fat_mv!(block_offset, oldname, newname) | 0.14.0 | Rename the specified file even if newname already exists.

--- a/src/functions.c
+++ b/src/functions.c
@@ -564,8 +564,16 @@ int fat_write_validate(struct fun_context *fctx)
     if (fctx->type != FUN_CONTEXT_FILE)
         ERR_RETURN("fat_write only usable in on-resource");
 
-    if (fctx->argc != 3)
-        ERR_RETURN("fat_write requires a block offset and destination filename");
+    if (fctx->argc == 2) {
+        // Default the filename to the resource name. This is quite common.
+        // Making this change at the validation stage means that the update is
+        // reflected in the output .fw file and it will be compatible with older
+        // versions of fwup.
+        fctx->argc = 3;
+        fctx->argv[2] = fctx->task->title;
+    } else if (fctx->argc != 3) {
+        ERR_RETURN("fat_write requires a block offset and optional destination filename");
+    }
 
     CHECK_ARG_UINT64(fctx->argv[1], "fat_write requires a non-negative integer block offset");
 

--- a/tests/192_resource_group.test
+++ b/tests/192_resource_group.test
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+#
+# Test resources in subdirectories
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+file-resource-group a_resource_group {
+  host-path-match = "${TESTS_SRC_DIR}/*"
+}
+
+task complete {
+	on-init {
+    mbr_write(mbr-a)
+    fat_mkfs(\${BOOT_PART_OFFSET}, \${BOOT_PART_COUNT})
+  }
+  on-resource-group a_resource_group {
+    fat_write(\${BOOT_PART_OFFSET})
+  }
+}
+EOF
+
+cat >$EXPECTED_META_CONF <<EOF
+file-resource "subdir/onesubdir" {
+  length=1024
+  blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+file-resource "/rootfile" {
+  length=1024
+  blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+file-resource "subdir1/subdir2/twosubdir" {
+  length=1024
+  blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+task "complete" {
+  on-resource "subdir/onesubdir" {
+    funlist = {"2", "raw_write", "0"}
+  }
+  on-resource "/rootfile" {
+    funlist = {"2", "raw_write", "4"}
+  }
+  on-resource "subdir1/subdir2/twosubdir" {
+    funlist = {"2", "raw_write", "8"}
+  }
+}
+EOF
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+
+EXPECTED_OUTPUT=$WORK/expected.out
+ACTUAL_OUTPUT=$WORK/actual.out
+
+cat >$EXPECTED_OUTPUT << EOF
+ Volume in drive : has no label
+ Volume Serial Number is 0022-2DB6
+Directory for ::/
+
+1K       bin      1024 1980-01-01   0:00
+        1 file                1 024 bytes
+                         38 909 440 bytes free
+
+EOF
+
+# Check that the directory looks right
+mdir -i $WORK/fwup.img@@32256 > $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT $ACTUAL_OUTPUT
+
+# Check the contents of the file
+mcopy -n -i $WORK/fwup.img@@32256 ::/1K.bin $WORK/actual.1K.bin
+diff $TESTFILE_1K $WORK/actual.1K.bin
+
+# Check the FAT file format using fsck
+dd if=$WORK/fwup.img skip=63 of=$WORK/vfat.img
+$FSCK_FAT $WORK/vfat.img
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/194_implicit_fat_write.test
+++ b/tests/194_implicit_fat_write.test
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+#
+# Test a file to a FAT file system without specifying the filename for a fat_write.
+# Note: This is a copy/paste of 012_fat_write.test with the fat_write call modified.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+define(BOOT_PART_OFFSET, 63)
+define(BOOT_PART_COUNT, 77238)
+
+file-resource 1K.bin {
+	host-path = "${TESTFILE_1K}"
+}
+file-resource subdir/1K.bin {
+	host-path = "${TESTFILE_1K}"
+}
+
+mbr mbr-a {
+    partition 0 {
+        block-offset = \${BOOT_PART_OFFSET}
+        block-count = \${BOOT_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+}
+task complete {
+	on-init {
+                mbr_write(mbr-a)
+                fat_mkfs(\${BOOT_PART_OFFSET}, \${BOOT_PART_COUNT})
+                fat_mkdir(\${BOOT_PART_OFFSET}, "subdir")
+        }
+        on-resource 1K.bin { fat_write(\${BOOT_PART_OFFSET}) }
+        on-resource subdir/1K.bin { fat_write(\${BOOT_PART_OFFSET}) }
+}
+EOF
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+
+EXPECTED_OUTPUT=$WORK/expected.out
+ACTUAL_OUTPUT=$WORK/actual.out
+
+cat >$EXPECTED_OUTPUT << EOF
+ Volume in drive : has no label
+ Volume Serial Number is 0022-2DB6
+Directory for ::/
+
+subdir       <DIR>     1980-01-01   0:00
+1K       bin      1024 1980-01-01   0:00
+         2 files               1 024 bytes
+                          38 907 904 bytes free
+
+EOF
+
+# Check that the directory looks right
+mdir -i $WORK/fwup.img@@32256 > $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT $ACTUAL_OUTPUT
+
+# Check the contents of the file
+mcopy -n -i $WORK/fwup.img@@32256 ::/1K.bin $WORK/actual.1K.bin
+diff $TESTFILE_1K $WORK/actual.1K.bin
+
+mcopy -n -i $WORK/fwup.img@@32256 ::/subdir/1K.bin $WORK/actual2.1K.bin
+diff $TESTFILE_1K $WORK/actual2.1K.bin
+
+# Check the FAT file format using fsck
+dd if=$WORK/fwup.img skip=63 of=$WORK/vfat.img
+$FSCK_FAT $WORK/vfat.img
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -193,6 +193,7 @@ TESTS = 001_simple_fw.test \
 	190_one_metadata_cmdline.test \
 	191_disk_crypto_via_env.test \
 	192_delta_out_of_bound.test \
-	193_delta_fat_upgrade.test
+	193_delta_fat_upgrade.test \
+	194_implicit_fat_write.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This is needed to support the file resources being automatically added.
The nice part is that since it creates backwards compatible archives, it
can be used as a convenience in newer fwup.conf files.

For example, before you'd have to write:

```
        on-resource my_file.bin {
                fat_write(\${BOOT_PART_OFFSET}, "my_file.bin")
        }
```

Now you only have to specify `my_file.bin` once:

```
        on-resource my_file.bin {
                fat_write(\${BOOT_PART_OFFSET})
        }
```

This works for directories too so long as the resource has the directory
name in it.
