### PR TITLE
block_cache: check last block segment size

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -112,6 +112,7 @@ struct block_cache {
 int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool enable_trim, bool verify_writes, bool minimize_writes);
 int block_cache_trim(struct block_cache *bc, off_t offset, off_t count, bool hwtrim);
 int block_cache_trim_after(struct block_cache *bc, off_t offset, bool hwtrim);
+size_t block_cache_segment_size(struct block_cache *bc, off_t offset);
 int block_cache_pwrite(struct block_cache *bc, const void *buf, size_t count, off_t offset, bool streamed);
 int block_cache_pread(struct block_cache *bc, void *buf, size_t count, off_t offset);
 int block_cache_flush(struct block_cache *bc);

--- a/src/fwup.c
+++ b/src/fwup.c
@@ -703,11 +703,6 @@ int main(int argc, char **argv)
             output_fd = mmc_open(mmc_device_path);
         }
 
-        // Trim the detected image size down to a multiple of the block cache
-        // segment size (128 KB) since since fwup only writes full blocks. If
-        // this isn't done, it is possible to write beyond the end of file.
-        end_offset &= ~(BLOCK_CACHE_SEGMENT_SIZE - 1);
-
         // Make sure that the output opened successfully and don't allow the
         // filehandle to be passed to child processes.
         if (output_fd < 0) {


### PR DESCRIPTION
In the verified_segment_write, don't write past the end of the total number of blocks on the device.