### PR TITLE
Add --minimize-writes option

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -70,6 +70,9 @@ struct block_cache {
     // Read everything back after its written
     bool verify_writes;
 
+    // Read the block first before writing it to avoid an unnecessary write operation.
+    bool minimize_writes;
+
     // Counter for maintaining LRU
     uint32_t timestamp;
 
@@ -106,7 +109,7 @@ struct block_cache {
 #endif
 };
 
-int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool enable_trim, bool verify_writes);
+int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool enable_trim, bool verify_writes, bool minimize_writes);
 int block_cache_trim(struct block_cache *bc, off_t offset, off_t count, bool hwtrim);
 int block_cache_trim_after(struct block_cache *bc, off_t offset, bool hwtrim);
 int block_cache_pwrite(struct block_cache *bc, const void *buf, size_t count, off_t offset, bool streamed);

--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -487,7 +487,8 @@ int fwup_apply(const char *fw_filename,
                struct fwup_progress *progress,
                unsigned char *const*public_keys,
                bool enable_trim,
-               bool verify_writes)
+               bool verify_writes,
+               bool minimize_writes)
 {
     int rc = 0;
     unsigned char *meta_conf_signature = NULL;
@@ -536,7 +537,7 @@ int fwup_apply(const char *fw_filename,
     // Initialize the output. Nothing should have been written before now
     // and waiting to initialize the output until now forces the point.
     fctx.output = (struct block_cache *) malloc(sizeof(struct block_cache));
-    OK_OR_CLEANUP(block_cache_init(fctx.output, output_fd, end_offset, enable_trim, verify_writes));
+    OK_OR_CLEANUP(block_cache_init(fctx.output, output_fd, end_offset, enable_trim, verify_writes, minimize_writes));
 
     // Go through all of the tasks and find a matcher
     fctx.task = find_task(&fctx, task_prefix);

--- a/src/fwup_apply.h
+++ b/src/fwup_apply.h
@@ -28,6 +28,7 @@ int fwup_apply(const char *fw_filename,
                struct fwup_progress *progress,
                unsigned char *const* public_keys,
                bool enable_trim,
-               bool verify_writes);
+               bool verify_writes,
+               bool minimize_writes);
 
 #endif // FWUP_APPLY_H

--- a/tests/195_minimize_writes.test
+++ b/tests/195_minimize_writes.test
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+#
+# Verify that minimize writes will skip unnecessary writes
+#
+# This test works by writing an image twice, but the second time, it tells
+# the test fixure to corrupt the writes. Since the second write doesn't
+# happen, everything will be ok.
+#
+# Requires libwrite_shim.so helper
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+$HAS_WRITE_SHIM || exit 77
+
+cat >$CONFIG <<EOF
+file-resource 1K.bin {
+	host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+        on-resource 1K.bin {
+                raw_write(0)
+        }
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Write the file the first time.
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-verify-writes
+cp $IMGFILE $WORK/expected.img
+
+# Check that corruption is various places is detected
+if ! WRITE_SHIM_CORRUPT_OFFSET=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --minimize-writes --verify-writes; then
+    echo "Expected the write to be skipped, but it wasn't!"
+    exit 1
+fi
+cmp $IMGFILE $WORK/expected.img
+
+# Check that if minimize writes is off that the file gets corrupted
+if WRITE_SHIM_CORRUPT_OFFSET=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --no-minimize-writes --verify-writes; then
+    echo "Expected the file corruption to be detected when not skipping redundant writes"
+    exit 1
+fi
+if cmp $IMGFILE $WORK/expected.img; then
+    echo "Expected the file to be corrupted when not skipping redundant writes"
+    exit 1
+fi
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -194,6 +194,7 @@ TESTS = 001_simple_fw.test \
 	191_disk_crypto_via_env.test \
 	192_delta_out_of_bound.test \
 	193_delta_fat_upgrade.test \
-	194_implicit_fat_write.test
+	194_implicit_fat_write.test \
+	195_minimize_writes.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This option currently defaults to off.

By passing --minimize-writes, fwup will read a block before writing it.
If the block is unchanged, the write is skipped entirely. This is
desirable if you're really interested in minimizing write operations to
Flash memory. Reasons include Flash being slow and it's common to be
rewriting similar data, worry about wearing Flash out prematurely, and
general worry that each write has a small chance to fail.
