### PR TITLE
Support partial final writes and add --max-size option

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -93,8 +93,8 @@ struct block_cache {
     bool trimmed_remainder; // true if segments after end of bitfield are trimmed
     bool hw_trim_enabled;
 
-    // This tracks the number of blocks on the destination
-    uint32_t num_blocks;
+    // If end_offset > 0, then it's the last allowed offset
+    off_t end_offset;
 
     // Asynchronous writes
 #if USE_PTHREADS

--- a/src/functions.c
+++ b/src/functions.c
@@ -793,9 +793,10 @@ int gpt_write_run(struct fun_context *fctx)
 
     uint8_t *mbr_and_primary_gpt = malloc(FWUP_BLOCK_SIZE + GPT_SIZE);
     uint8_t *secondary_gpt = malloc(GPT_SIZE);
+    uint32_t num_blocks = fctx->output->end_offset / FWUP_BLOCK_SIZE; // end_offset can be 0 for unknown
 
     off_t secondary_gpt_offset;
-    OK_OR_CLEANUP(gpt_create_cfg(gptsec, fctx->output->num_blocks, mbr_and_primary_gpt, secondary_gpt, &secondary_gpt_offset));
+    OK_OR_CLEANUP(gpt_create_cfg(gptsec, num_blocks, mbr_and_primary_gpt, secondary_gpt, &secondary_gpt_offset));
 
     OK_OR_CLEANUP_MSG(block_cache_pwrite(fctx->output, mbr_and_primary_gpt, FWUP_BLOCK_SIZE + GPT_SIZE, 0, false),
                      "unexpected error writing protective mbr and primary gpt: %s", strerror(errno));
@@ -832,9 +833,10 @@ int mbr_write_run(struct fun_context *fctx)
 {
     const char *mbr_name = fctx->argv[1];
     cfg_t *mbrsec = cfg_gettsec(fctx->cfg, "mbr", mbr_name);
+    uint32_t num_blocks = fctx->output->end_offset / FWUP_BLOCK_SIZE; // end_offset can be 0 for unknown
 
     uint8_t buffer[FWUP_BLOCK_SIZE];
-    OK_OR_RETURN(mbr_create_cfg(mbrsec, fctx->output->num_blocks, buffer));
+    OK_OR_RETURN(mbr_create_cfg(mbrsec, num_blocks, buffer));
 
     OK_OR_RETURN_MSG(block_cache_pwrite(fctx->output, buffer, FWUP_BLOCK_SIZE, 0, false),
                      "unexpected error writing mbr: %s", strerror(errno));

--- a/tests/160_mbr_expand.test
+++ b/tests/160_mbr_expand.test
@@ -84,9 +84,9 @@ $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
 # the partition will be the specified block_size
 cmp_bytes 512 $WORK/unexpanded.img $IMGFILE
 
-# Now make the image file larger to see that the final partition is larger
-dd if=/dev/zero of=$IMGFILE bs=512 count=20480 2>/dev/null
-$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+# Repeat the test, but specify a max size so that the final partition is larger
+rm $IMGFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE --max-size=20480 -t complete
 cmp_bytes 512 $WORK/expanded.img $IMGFILE
 
 # Check that the verify logic works on this file

--- a/tests/166_gpt_expand.test
+++ b/tests/166_gpt_expand.test
@@ -119,9 +119,9 @@ $FWUP_CREATE -c -f $CONFIG -o $FWFILE
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
 cmp_bytes 6308864 $WORK/unexpanded.img $IMGFILE
 
-# Now make the image file larger to see that the final partition is larger
-dd if=/dev/zero of=$IMGFILE bs=512 count=20736 2>/dev/null
-$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+# Repeat the test, but specify a max size so that the final partition is larger
+rm $IMGFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE --max-size=20736 -t complete
 cmp $WORK/expanded.img $IMGFILE
 
 # Check that the verify logic works on this file

--- a/tests/196_small_destination.test
+++ b/tests/196_small_destination.test
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#
+# Test writing to destination that's less that the 128KB segment size
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+        host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+	on-resource TEST { raw_write(0) }
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Create the expected output with dd
+dd if=/dev/zero count=64 of=$WORK/expected.img 2>/dev/null
+dd if=$TESTFILE_1K of=$WORK/expected.img conv=notrunc 2>/dev/null
+
+# Constrain the firmware update to write to 32KB destination
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes --max-size=64
+
+cmp $IMGFILE $WORK/expected.img
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/197_fractional_end_segment.test
+++ b/tests/197_fractional_end_segment.test
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#
+# Test writing to destination who's last bytes are in a partial 128KB segment
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+        host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+	on-resource TEST { raw_write(256) }
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Create the expected output with dd
+dd if=/dev/zero count=256 of=$WORK/expected.img 2>/dev/null
+cat $TESTFILE_1K >> $WORK/expected.img
+
+# Constrain the firmware update to write to 128KB+1KB destination
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --verify-writes --max-size=258
+
+cmp $IMGFILE $WORK/expected.img
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/198_gpt_partial-generate.sh
+++ b/tests/198_gpt_partial-generate.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e
+
+# Adapted from Buildroot
+
+# GPT partition type UUIDs
+esp_type=c12a7328-f81f-11d2-ba4b-00a0c93ec93b
+linux_type=44479540-f297-41b2-9af7-d131d5f0458a
+
+# Hardcode UUIDs for reproducible images (call uuidgen to make more)
+disk_uuid=b443fbeb-2c93-481b-88b3-0ecb0aeba911
+efi_part_uuid=5278721d-0089-4768-85df-b8f1b97e6684
+root_part_uuid=fcc205c8-2f1c-4dcd-bef4-7b209aa15cca
+
+# Boot partition offset and size, in 512-byte sectors
+efi_part_start=64
+efi_part_size=32768
+
+# Rootfs partition offset and size, in 512-byte sectors
+root_part_start=$(( efi_part_start + efi_part_size ))
+root_part_size=65504
+
+gpt_size=33
+
+first_lba=$(( 1 + gpt_size ))
+last_lba=$(( root_part_start + root_part_size ))
+
+# Disk image size in 512-byte sectors
+image_size=$(( last_lba + gpt_size + 1 ))
+
+primary_gpt_lba=0
+secondary_gpt_lba=$(( image_size - gpt_size ))
+
+rm -f disk.img disk-primary-gpt.img disk-secondary-gpt.img
+dd if=/dev/zero of=disk.img bs=512 count=0 seek=$image_size 2>/dev/null
+
+sfdisk disk.img <<EOF
+label: gpt
+label-id: $disk_uuid
+device: /dev/foobar0
+unit: sectors
+first-lba: $first_lba
+last-lba: $last_lba
+
+/dev/foobar0p1 : start=$efi_part_start,  size=$efi_part_size,  type=$esp_type,   uuid=$efi_part_uuid,  name="efi-part.vfat"
+/dev/foobar0p2 : start=$root_part_start, size=$root_part_size, type=$linux_type, uuid=$root_part_uuid, name="rootfs.ext2"
+EOF
+
+echo
+echo "Add the following to the unit test"
+echo
+echo "base64_decodez >\$WORK/expected-primary-gpt.img <<EOF"
+dd if=disk.img bs=512 count=$gpt_size skip=$primary_gpt_lba 2>/dev/null | gzip -c | base64
+echo "EOF"
+echo "base64_decodez >\$WORK/expected-secondary-gpt.img <<EOF"
+dd if=disk.img bs=512 count=$gpt_size skip=$secondary_gpt_lba 2>/dev/null | gzip -c | base64
+echo "EOF"
+echo "cp \$WORK/expected-primary-gpt.img \$WORK/expected.img"
+echo "dd if=\$WORK/expected-secondary-gpt.img of=\$WORK/expected.img bs=512 seek=$secondary_gpt_lba conv=notrunc"
+
+

--- a/tests/198_gpt_partial.test
+++ b/tests/198_gpt_partial.test
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+#
+# Test the GPT creation ability of fwup but with a partial 128KB segment at end
+#
+# This is the same as 163_gpt.test except with a search/replace of 65536 with
+# 65504.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+define(EFI_TYPE, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b")
+define(LINUX_TYPE, "44479540-f297-41b2-9af7-d131d5f0458a")
+
+define(DISK_UUID, "b443fbeb-2c93-481b-88b3-0ecb0aeba911")
+define(EFI_PART_UUID, "5278721d-0089-4768-85df-b8f1b97e6684")
+define(ROOTFS_PART_UUID, "fcc205c8-2f1c-4dcd-bef4-7b209aa15cca")
+
+define(EFI_PART_OFFSET, 64)
+define(EFI_PART_COUNT, 32768)
+define-eval(ROOTFS_PART_OFFSET, "\${EFI_PART_OFFSET} + \${EFI_PART_COUNT}")
+define(ROOTFS_PART_COUNT, 65504)
+
+gpt gpt-a {
+    guid = \${DISK_UUID}
+
+    partition 0 {
+        block-offset = \${EFI_PART_OFFSET}
+        block-count = \${EFI_PART_COUNT}
+        type = \${EFI_TYPE}
+        guid = \${EFI_PART_UUID}
+        name = "efi-part.vfat"
+    }
+    partition 1 {
+        block-offset = \${ROOTFS_PART_OFFSET}
+        block-count = \${ROOTFS_PART_COUNT}
+        type = \${LINUX_TYPE}
+        guid = \${ROOTFS_PART_UUID}
+        name = "rootfs.ext2"
+    }
+}
+task complete {
+	on-init {
+                gpt_write(gpt-a)
+        }
+}
+EOF
+
+# Create the expected output from sfdisk by running ./198_gpt_partial-generate.sh on
+# Linux.
+base64_decodez >$WORK/expected-primary-gpt.img <<EOF
+H4sIAAAAAAAAA+3SzyuDcRzA8c+zcnFQOzmgPSkl+dFcFc8TM0tKi9suO2zZyXq2WCk9Bwq3Jamd
+OM4RBxyUnYwcppz9ASuxFEU9vuq7A7fHQdT79e1bn8/316dPfUXwnwXkwfM8Q0W2a/i+PX8QmYyZ
+s3Z8TsSQhFrpKS63f+4032q+2q1zU+f1t/Hj7f6OqY2jtuvWejkY0PuunuFaJfuzjvCbenN9F6HX
+2+DZtOxVR6sjXU4hvikL0fX7k6fT1fSapc+NuV/vpSQtGRmQrCTFkbwMypJaSarIH2snOrHbOLRL
+L7Xw3WNk67Kl8t45dDNz/rxilvYTV5auG/r2ux1ZVCOvauZU7ZQUVDzsv30AAAAAAAAAAAAAAAAA
+AAAAAAAAAAAA+DM+AHVn3/EAQgAA
+EOF
+base64_decodez >$WORK/expected-secondary-gpt.img <<EOF
+H4sIAAAAAAAAA+3bPUsDQRSF4ZNCBAshtUpWqyB+EFtBd9EYRQQJlmlSbNDKsAkSEGQLBbUVEbbS
+0lYt1EIwlVEsIlj7A9KoCApaOOJYpIyFWLzPMMydC8NhfsBNlvovE2938fNZ7dfGaqM9QSW7pcXM
+xsPp09laYd3Vt/FQTXwVtKRBFZVXoLKGtGI6eVO1xt3NTO49H3nRaz11/5jevmqrfnQP385dvKw6
+0UHu2rW5iTDW9C7Qslllk1ky2b4qph5pMRsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgP8iPTXjzHvZ
+BSmmnLn7yfboq+/Zefufqfs+ezq233ifONkZ6JrePO686WgcxnttP7Q7Va8W/+oP+L1PgzKlBABC
+AAA=
+EOF
+cp $WORK/expected-primary-gpt.img $WORK/expected.img
+dd if=$WORK/expected-secondary-gpt.img of=$WORK/expected.img bs=512 seek=98337 conv=notrunc
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --max-size=98370
+
+cmp $WORK/expected.img $IMGFILE
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -197,6 +197,7 @@ TESTS = 001_simple_fw.test \
 	194_implicit_fat_write.test \
 	195_minimize_writes.test \
 	196_small_destination.test \
-	197_fractional_end_segment.test
+	197_fractional_end_segment.test \
+	198_gpt_partial.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -195,6 +195,8 @@ TESTS = 001_simple_fw.test \
 	192_delta_out_of_bound.test \
 	193_delta_fat_upgrade.test \
 	194_implicit_fat_write.test \
-	195_minimize_writes.test
+	195_minimize_writes.test \
+	196_small_destination.test \
+	197_fractional_end_segment.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
There was a constraint that would round the destination to a multiple of
128KB segments so that <128KB writes didn't need to be handled. These
are now handled, but only for the very last 128KB segment.

A --max-size option was added to make testing this feature possible on
regular files. For real devices, the max size is automatically
determined from the device. This option can reduce the max size of a
real device.

Internally, the variable tracking the max size (end_offset) is now a
hard limit. It used to be a soft limit so that it was possible to infer
a good guess from a regular file. That was interesting for testing MBR
and GPT functionality, but not really anywhere else. The hard limit
makes it possible calculate the partial write size at the end of the
device and to give a better error if fwup is told to write past the end.
