### PR TITLE
Improve GPT test with partial final segment

### DIFF
--- a/tests/198_gpt_partial-generate.sh
+++ b/tests/198_gpt_partial-generate.sh
@@ -19,12 +19,15 @@ efi_part_size=32768
 
 # Rootfs partition offset and size, in 512-byte sectors
 root_part_start=$(( efi_part_start + efi_part_size ))
-root_part_size=65504
+root_part_size=65536
+
+# Padding to push the entire size to a non-128K byte offset
+padding=32
 
 gpt_size=33
 
 first_lba=$(( 1 + gpt_size ))
-last_lba=$(( root_part_start + root_part_size ))
+last_lba=$(( root_part_start + root_part_size + padding))
 
 # Disk image size in 512-byte sectors
 image_size=$(( last_lba + gpt_size + 1 ))

--- a/tests/198_gpt_partial.test
+++ b/tests/198_gpt_partial.test
@@ -20,7 +20,7 @@ define(ROOTFS_PART_UUID, "fcc205c8-2f1c-4dcd-bef4-7b209aa15cca")
 define(EFI_PART_OFFSET, 64)
 define(EFI_PART_COUNT, 32768)
 define-eval(ROOTFS_PART_OFFSET, "\${EFI_PART_OFFSET} + \${EFI_PART_COUNT}")
-define(ROOTFS_PART_COUNT, 65504)
+define(ROOTFS_PART_COUNT, 65536)
 
 gpt gpt-a {
     guid = \${DISK_UUID}
@@ -50,27 +50,27 @@ EOF
 # Create the expected output from sfdisk by running ./198_gpt_partial-generate.sh on
 # Linux.
 base64_decodez >$WORK/expected-primary-gpt.img <<EOF
-H4sIAAAAAAAAA+3SzyuDcRzA8c+zcnFQOzmgPSkl+dFcFc8TM0tKi9suO2zZyXq2WCk9Bwq3Jamd
-OM4RBxyUnYwcppz9ASuxFEU9vuq7A7fHQdT79e1bn8/316dPfUXwnwXkwfM8Q0W2a/i+PX8QmYyZ
-s3Z8TsSQhFrpKS63f+4032q+2q1zU+f1t/Hj7f6OqY2jtuvWejkY0PuunuFaJfuzjvCbenN9F6HX
-2+DZtOxVR6sjXU4hvikL0fX7k6fT1fSapc+NuV/vpSQtGRmQrCTFkbwMypJaSarIH2snOrHbOLRL
-L7Xw3WNk67Kl8t45dDNz/rxilvYTV5auG/r2ux1ZVCOvauZU7ZQUVDzsv30AAAAAAAAAAAAAAAAA
-AAAAAAAAAAAA+DM+AHVn3/EAQgAA
+H4sIAAAAAAAAA+3SzyuDcRzA8c+z2sVB7WyynJBNc1U8w4y00uJkBztscaJno5XSoyhcJbUTR444
+2A6Kk/mRKGd/wEpIUdTjq77PYcfHQdT79e1bn8/316dPfUXwn/nk0XEcQ0XLtuH59sR+fGgkNBZL
+jYsYklYrV+3R+e8d9y331VadT+m89jFwtNnZNLx22HjZUNsL+PS+refNZLD/Zx3hN7XlO05b3u8C
+lVHZqfZWe5qtYmpdphOrD8fP5aXciqnP9dn197KSkxkJy5xkxJKCRGRBrWRU5I25lRjcfjmIld5u
+o/dP8Y1z/9lnsOs6efK6GCrtpi9M261f/7stmVWjoGrmVe2sFFXc7b19AAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAPgzvgCgS9s5AEIAAA==
 EOF
 base64_decodez >$WORK/expected-secondary-gpt.img <<EOF
-H4sIAAAAAAAAA+3bPUsDQRSF4ZNCBAshtUpWqyB+EFtBd9EYRQQJlmlSbNDKsAkSEGQLBbUVEbbS
-0lYt1EIwlVEsIlj7A9KoCApaOOJYpIyFWLzPMMydC8NhfsBNlvovE2938fNZ7dfGaqM9QSW7pcXM
-xsPp09laYd3Vt/FQTXwVtKRBFZVXoLKGtGI6eVO1xt3NTO49H3nRaz11/5jevmqrfnQP385dvKw6
-0UHu2rW5iTDW9C7Qslllk1ky2b4qph5pMRsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgP8iPTXjzHvZ
-BSmmnLn7yfboq+/Zefufqfs+ezq233ifONkZ6JrePO686WgcxnttP7Q7Va8W/+oP+L1PgzKlBABC
+H4sIAAAAAAAAA+3bsSvEYRzH8c8NFoO62V0uk+SIVfE7nHNJ6bK5wW+4i4l+d+mi9FMU1iN1E6MV
+AwbF5EiilM0fcAtSFINHnhtuPIMM79fT0/N9vvX06fkDvm259rOW97vgyah2yn3l3rBXSK1rOrH6
+ePR8vJRdcfSj31eNjLKaUVRzcuUpr07Nm45rqvo4W4mh7Zf9WOnttvv+Kb5x0XD+Geq6Hjt9XYyU
+dtOXjl/ND9S88zRrVt5k5kx2RgVT99SZDQAAAAAAAAAAAAAAAAAAAAAAAAAAAADAfxEfTkbGY6kJ
+KaC0uW8uPIS/+8t23r46dd9qzynbr3wMHhY7mkfWDpquGit7Qdf2fbtvJkMDf/UH/N4XQ6EbhABC
 AAA=
 EOF
 cp $WORK/expected-primary-gpt.img $WORK/expected.img
-dd if=$WORK/expected-secondary-gpt.img of=$WORK/expected.img bs=512 seek=98337 conv=notrunc
+dd if=$WORK/expected-secondary-gpt.img of=$WORK/expected.img bs=512 seek=98401 conv=notrunc
 
 # Create the firmware file, then "burn it"
 $FWUP_CREATE -c -f $CONFIG -o $FWFILE
-$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --max-size=98370
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --max-size=98434
 
 cmp $WORK/expected.img $IMGFILE
 

--- a/tests/199_partial_read.test
+++ b/tests/199_partial_read.test
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+#
+# Exercise reading a partial segment using require-partition on a silly small
+# disk.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+
+# +-----------------------------+
+# | MBR                         |
+# +-----------------------------+
+# | p0: Boot (Simulated)        |
+# +-----------------------------+
+# | p1*: Rootfs A (Simulated)   |
+# +-----------------------------+
+# | p1*: Rootfs B (Simulated)   |
+# +-----------------------------+
+# | p2: Data (Simulated)        |
+# +-----------------------------+
+
+define(BOOT_PART_OFFSET, 2)
+define(BOOT_PART_COUNT, 4)
+define(ROOTFS_A_PART_OFFSET, 8)
+define(ROOTFS_A_PART_COUNT, 8)
+define(ROOTFS_B_PART_OFFSET, 16)
+define(ROOTFS_B_PART_COUNT, 8)
+define(APP_PART_OFFSET, 24)
+define(APP_PART_COUNT, 16)
+
+mbr mbr-a {
+    partition 0 {
+        block-offset = \${BOOT_PART_OFFSET}
+        block-count = \${BOOT_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = \${ROOTFS_A_PART_OFFSET}
+        block-count = \${ROOTFS_A_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = \${APP_PART_OFFSET}
+        block-count = \${APP_PART_COUNT}
+        type = 0xc # FAT32
+    }
+    # partition 3 is unused
+}
+
+mbr mbr-b {
+    partition 0 {
+        block-offset = \${BOOT_PART_OFFSET}
+        block-count = \${BOOT_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = \${ROOTFS_B_PART_OFFSET}
+        block-count = \${ROOTFS_B_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = \${APP_PART_OFFSET}
+        block-count = \${APP_PART_COUNT}
+        type = 0xc # FAT32
+    }
+    # partition 3 is unused
+}
+
+# This firmware task writes everything to the destination media
+task complete {
+    on-init {
+        mbr_write(mbr-a)
+    }
+}
+task upgrade.a {
+    # This task upgrades the A partition and runs when partition B
+    # is being used.
+    require-partition-offset(1, \${ROOTFS_B_PART_OFFSET})
+    on-finish { mbr_write(mbr-a) }
+}
+task upgrade.b {
+    # This task upgrades the B partition and runs when partition B
+    # is being used.
+    require-partition-offset(1, \${ROOTFS_A_PART_OFFSET})
+    on-finish { mbr_write(mbr-b) }
+}
+
+# This task is just needed to help support the unit test
+task dump_mbr_b {
+    on-init {
+        mbr_write(mbr-b)
+    }
+}
+EOF
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --max-size=64
+cp $IMGFILE $WORK/mbr_a.bin
+
+# Now upgrade the IMGFILE file
+# VERIFY_LAST_WRITE checks that MBR is written last
+VERIFY_LAST_WRITE=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t upgrade --max-size=64
+
+VERIFY_SYSCALLS_CHECKPATH=$WORK/mbr_b.bin $FWUP_APPLY -a -d $WORK/mbr_b.bin -i $FWFILE -t dump_mbr_b --max-size=64
+cmp_bytes 512 $WORK/mbr_b.bin $IMGFILE 0 0         # Updated
+
+# Do it again
+VERIFY_LAST_WRITE=0 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t upgrade --max-size=64
+cmp_bytes 512 $WORK/mbr_a.bin $IMGFILE 0 0         # Updated
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -198,6 +198,7 @@ TESTS = 001_simple_fw.test \
 	195_minimize_writes.test \
 	196_small_destination.test \
 	197_fractional_end_segment.test \
-	198_gpt_partial.test
+	198_gpt_partial.test \
+	199_partial_read.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This adjusts the generation script to add some padding that's not in any
partition to push the secondary header into a partial final segment.
This is a better test since it exercises fwup's GPT secondary header
placement code in a more obvious way. The test came too close to working
without the partial final segment commit for comfort.
