### PR TITLE
Do not autodetect very small drives

### DIFF
--- a/src/mmc.h
+++ b/src/mmc.h
@@ -32,6 +32,7 @@
 //       large capacity and we don't want to autodetect them when looking for
 //       SDCards.
 #define MMC_MAX_AUTODETECTED_SIZE (129 * ONE_GiB)
+#define MMC_MIN_AUTODETECTED_SIZE (ONE_MiB)
 
 struct mmc_device {
     char name[MMC_DEVICE_NAME_LEN];

--- a/src/mmc_bsd.c
+++ b/src/mmc_bsd.c
@@ -76,8 +76,8 @@ static bool is_autodetectable_mmc_device(const struct mmc_device_info *info,
     if (info->st.st_rdev == (rootdev->st_dev & 0xfff0))
         return false;
 
-    // Check 2: Zero capacity devices
-    if (info->device_size <= 0)
+    // Check 2: Very small and zero capacity devices
+    if (info->device_size < MMC_MIN_AUTODETECTED_SIZE)
         return false;
 
     // Check 3: Capacity larger than max autodetectable size -> false

--- a/src/mmc_linux.c
+++ b/src/mmc_linux.c
@@ -153,8 +153,8 @@ static bool is_autodetectable_mmc_device(const struct mmc_device_info *info, dev
     if (info->st.st_rdev == rootdev)
         return false;
 
-    // Check 2: Zero capacity devices
-    if (info->device_size <= 0)
+    // Check 2: Small or zero capacity devices
+    if (info->device_size < MMC_MIN_AUTODETECTED_SIZE)
         return false;
 
     // Check 3: Only allow removable drives

--- a/src/mmc_osx.c
+++ b/src/mmc_osx.c
@@ -109,8 +109,10 @@ static void scan_disk_appeared_cb(DADiskRef disk, void *c)
 
         CFRelease(info);
 
-        // Filter out virtual devices like Time Machine network backup drives
-        if (is_virtual)
+        // Filter out unlikely devices:
+        //   1. Virtual devices like Time Machine network backup drives
+        //   2. Really small devices like those that those that just contain device docs
+        if (is_virtual || size < MMC_MIN_AUTODETECTED_SIZE)
             return;
 
         context->count++;


### PR DESCRIPTION
The size is set to 1 MiB, so it's much smaller than any use of fwup that
I've seen. It will help reduce false positives from devices that have
docs on a small read-only drive.

Fixes #222
