### PR TITLE
Fix test failures using mtools

### DIFF
--- a/tests/011_fat_setlabel.test
+++ b/tests/011_fat_setlabel.test
@@ -45,7 +45,7 @@ No files
 
 EOF
 
-mdir -i $WORK/fwup.img@@32256 > $ACTUAL_OUTPUT
+LC_ALL= mdir -i $WORK/fwup.img@@32256 > $ACTUAL_OUTPUT
 diff -w $EXPECTED_OUTPUT $ACTUAL_OUTPUT
 
 # IMPORTANT: The volume label is actually supposed to be stored twice. Once in

--- a/tests/066_fat_attrib.test
+++ b/tests/066_fat_attrib.test
@@ -53,7 +53,7 @@ cat >$EXPECTED_OUTPUT << EOF
 EOF
 
 # Check that the attributes look right
-mattrib -i $WORK/fwup.img@@32256 system.txt hidden.txt readonly.txt shr.txt > $ACTUAL_OUTPUT
+LC_ALL= mattrib -i $WORK/fwup.img@@32256 system.txt hidden.txt readonly.txt shr.txt > $ACTUAL_OUTPUT
 diff -w $EXPECTED_OUTPUT $ACTUAL_OUTPUT
 
 # Check the FAT file format using fsck

--- a/tests/156_fat_truncation_bug.test
+++ b/tests/156_fat_truncation_bug.test
@@ -124,10 +124,10 @@ EOF
 
 
 # Check that the directories look right
-MTOOLS_SKIP_CHECK=1 mdir -i $WORK/fwup.img@@30720 > $ACTUAL_OUTPUT.1
+LC_ALL= MTOOLS_SKIP_CHECK=1 mdir -i $WORK/fwup.img@@30720 > $ACTUAL_OUTPUT.1
 diff -w $EXPECTED_OUTPUT.1 $ACTUAL_OUTPUT.1
 
-MTOOLS_SKIP_CHECK=1 mdir -i $WORK/fwup.img@@542720 > $ACTUAL_OUTPUT.2
+LC_ALL= MTOOLS_SKIP_CHECK=1 mdir -i $WORK/fwup.img@@542720 > $ACTUAL_OUTPUT.2
 diff -w $EXPECTED_OUTPUT.2 $ACTUAL_OUTPUT.2
 
 # Check the contents of the files


### PR DESCRIPTION
mtools utilities now output underscores when `LC_ALL` is set to show you
hidden spaces in names. This is helpful, but breaks the unit tests.
Since it just seems to be in the latest mtools versions, turn it off by
unsetting `LC_ALL`.
