### PR TITLE
When writing regular files, check file size to support expansion

### DIFF
--- a/src/fwup.c
+++ b/src/fwup.c
@@ -687,6 +687,8 @@ int main(int argc, char **argv)
                 fwup_warnx("ignoring --enable-trim since operating on a regular file");
                 enable_trim = false;
             }
+            // Regular files can always be the --max-size assuming enough disk space, so
+            // force the end_offset outright if set.
             if (max_size_blocks > 0)
                 end_offset = FWUP_BLOCK_SIZE * max_size_blocks;
         } else if (is_device_null(mmc_device_path)) {

--- a/src/fwup.c
+++ b/src/fwup.c
@@ -678,6 +678,10 @@ int main(int argc, char **argv)
                     close(output_fd);
                     output_fd = -1;
                 }
+                // If the image file already has a size, go by the file's size.
+                // This is the Qemu disk image use case.
+                if (st.st_size > 0)
+                    end_offset = st.st_size;
             }
             if (enable_trim) {
                 fwup_warnx("ignoring --enable-trim since operating on a regular file");

--- a/tests/160_mbr_expand.test
+++ b/tests/160_mbr_expand.test
@@ -89,5 +89,12 @@ rm $IMGFILE
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE --max-size=20480 -t complete
 cmp_bytes 512 $WORK/expanded.img $IMGFILE
 
+# Repeat the test, but now apply to a large regular file. This is a common qemu
+# use case.
+rm $IMGFILE
+dd if=/dev/zero of=$IMGFILE seek=20480 count=0
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+cmp_bytes 512 $WORK/expanded.img $IMGFILE
+
 # Check that the verify logic works on this file
 $FWUP_VERIFY -V -i $FWFILE

--- a/tests/160_mbr_expand.test
+++ b/tests/160_mbr_expand.test
@@ -96,5 +96,11 @@ dd if=/dev/zero of=$IMGFILE seek=20480 count=0
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
 cmp_bytes 512 $WORK/expanded.img $IMGFILE
 
+# Repeat the test, but check that --max-size overrides existing file size
+rm $IMGFILE
+dd if=/dev/zero of=$IMGFILE seek=19480 count=0
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE --max-size=20480 -t complete
+cmp_bytes 512 $WORK/expanded.img $IMGFILE
+
 # Check that the verify logic works on this file
 $FWUP_VERIFY -V -i $FWFILE

--- a/tests/166_gpt_expand.test
+++ b/tests/166_gpt_expand.test
@@ -124,5 +124,12 @@ rm $IMGFILE
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE --max-size=20736 -t complete
 cmp $WORK/expanded.img $IMGFILE
 
+# Repeat the test, but now apply to a large regular file. This is a common qemu
+# use case.
+rm $IMGFILE
+dd if=/dev/zero of=$IMGFILE seek=20736 count=0
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+cmp $WORK/expanded.img $IMGFILE
+
 # Check that the verify logic works on this file
 $FWUP_VERIFY -V -i $FWFILE

--- a/tests/172_delta_upgrade.test
+++ b/tests/172_delta_upgrade.test
@@ -25,6 +25,7 @@ file-resource rootfs.next {
 }
 
 task complete {
+    on-init { raw_memset(\${ROOTFS_B_PART_OFFSET}, \${ROOTFS_B_PART_COUNT}, 0) }
     on-resource rootfs.original { raw_write(\${ROOTFS_A_PART_OFFSET}) }
 }
 task upgrade {

--- a/tests/174_streamed_delta_upgrade.test
+++ b/tests/174_streamed_delta_upgrade.test
@@ -27,6 +27,7 @@ file-resource rootfs.next {
 }
 
 task complete {
+    on-init { raw_memset(\${ROOTFS_B_PART_OFFSET}, \${ROOTFS_B_PART_COUNT}, 0) }
     on-resource rootfs.original { raw_write(\${ROOTFS_A_PART_OFFSET}) }
 }
 task upgrade {

--- a/tests/192_delta_out_of_bound.test
+++ b/tests/192_delta_out_of_bound.test
@@ -22,6 +22,7 @@ file-resource rootfs.next {
 }
 
 task complete {
+    on-init { raw_memset(\${ROOTFS_B_PART_OFFSET}, \${ROOTFS_B_PART_COUNT}, 0) }
     on-resource rootfs.original { raw_write(\${ROOTFS_A_PART_OFFSET}) }
 }
 task upgrade {

--- a/tests/201_sign_delta_upgrade2.test
+++ b/tests/201_sign_delta_upgrade2.test
@@ -28,6 +28,7 @@ file-resource rootfs.next {
 }
 
 task complete {
+    on-init { raw_memset(\${ROOTFS_B_PART_OFFSET}, \${ROOTFS_B_PART_COUNT}, 0) }
     on-resource rootfs.original { raw_write(\${ROOTFS_A_PART_OFFSET}) }
 }
 task upgrade {


### PR DESCRIPTION
This makes writing external media and regular files work more similar.
Automatic size checks were never hooked up for regular files even though 
this is a very convenient use case when using Qemu. This change 
implements it.

The way this works is that Qemu users first create a disk image. This is
just a big sparse file and then they run fwup to program the initial
image. The disk image size will be total image size in this case, so the
expansion and end-seeking functionality is expected to work.

When the destination file does not exist or is 0, fwup works as it
previously does by only writing the minimum size possible or following
the `--max-size` commandline argument.

IMPORTANT: Regular files no longer automatically expand if they're
nonzero in size. This can break test scripts, but if it were still
supported, forcing a max size like is done for physical media wouldn't
work for qemu disk images. The fix is to remove old image files if you
don't care about them or to use `dd seek=x` to make them the right size
or to update the complete task in the fwup files to write to the full
size. The last option is what's being done for the unit tests.
