### PR TITLE
Support copying between FAT partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ error(message)                          | 0.12.0 | Immediately fail a firmware u
 execute(command)                        | 0.16.0 | Execute a command on the host. Requires the `--unsafe` flag
 fat_attrib(block_offset, filename, attrib) | 0.1.0 | Modify a file's attributes. attrib is a string like "RHS" where R=readonly, H=hidden, S=system
 fat_cp(block_offset, from, to)          | 0.3.0 | Copy a file on one partition
+fat_cp(from_offset, from, to_offset, to) | 1.12.0 | Copy a file between partitions
 fat_mkdir(block_offset, filename)       | 0.2.0 | Create a directory on a FAT file system. This also succeeds if the directory already exists.
 fat_mkfs(block_offset, block_count)     | 0.1.0 | Create a FAT file system at the specified block offset and count
 fat_mv(block_offset, oldname, newname)  | 0.1.0 | Rename the specified file on a FAT file system

--- a/src/3rdparty/fatfs/source/ffconf.h
+++ b/src/3rdparty/fatfs/source/ffconf.h
@@ -166,7 +166,7 @@
 / Drive/Volume Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_VOLUMES		1
+#define FF_VOLUMES		4
 /* Number of volumes (logical drives) to be used. (1-10) */
 
 

--- a/src/fatfs.c
+++ b/src/fatfs.c
@@ -321,21 +321,25 @@ int fatfs_mv(struct block_cache *output, off_t block_offset, const char *cmd, co
 
 /**
  * @brief fatfs_cp copy a file
- * @param fc the current FAT session
+ * @param output the cache
+ * @param from_offset from FAT filesystem block offset
  * @param from_name original filename
- * @param to_name the name of the copy filename
+ * @param to_offset to FAT filesystem block offset
+ * @param to_name the name of the destination
  * @return 0 on success
  */
-int fatfs_cp(struct block_cache *output, off_t block_offset, const char *from_name, const char *to_name)
+int fatfs_cp(struct block_cache *output, off_t from_offset, const char *from_name, off_t to_offset, const char *to_name)
 {
     close_open_files();
-    TCHAR mount_path[3];
-    OK_OR_RETURN(maybe_mount(output, block_offset, 0, mount_path));
+    TCHAR from_mount_path[3];
+    TCHAR to_mount_path[3];
+    OK_OR_RETURN(maybe_mount(output, from_offset, 0, from_mount_path));
+    OK_OR_RETURN(maybe_mount(output, to_offset, 0, to_mount_path));
 
     TCHAR absolute_from_name[FATFS_MAX_PATH];
-    concatenate_path(mount_path, from_name, absolute_from_name);
+    concatenate_path(from_mount_path, from_name, absolute_from_name);
     TCHAR absolute_to_name[FATFS_MAX_PATH];
-    concatenate_path(mount_path, to_name, absolute_to_name);
+    concatenate_path(to_mount_path, to_name, absolute_to_name);
 
     FIL fromfil;
     FIL tofil;

--- a/src/fatfs.h
+++ b/src/fatfs.h
@@ -40,7 +40,7 @@ int fatfs_rm(struct block_cache *output, off_t block_offset, const char *cmd, co
 int fatfs_truncate(struct block_cache *output, off_t block_offset, const char *filename);
 int fatfs_pread(struct block_cache *output, off_t block_offset, const char *filename, int offset, size_t size, void *buffer);
 int fatfs_pwrite(struct block_cache *output, off_t block_offset, const char *filename, int offset, const char *buffer, off_t size);
-int fatfs_cp(struct block_cache *output, off_t block_offset, const char *from_name, const char *to_name);
+int fatfs_cp(struct block_cache *output, off_t from_offset, const char *from_name, off_t to_offset, const char *to_name);
 int fatfs_touch(struct block_cache *output, off_t block_offset, const char *filename);
 int fatfs_exists(struct block_cache *output, off_t block_offset, const char *filename);
 int fatfs_file_matches(struct block_cache *output, off_t block_offset, const char *filename, const char *pattern);

--- a/tests/203_multi_fat.test
+++ b/tests/203_multi_fat.test
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+#
+# Test that mounting lots of FAT file systems simultaneously works.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+define(FAT1_PART_OFFSET, 0)
+define(FAT1_PART_COUNT, 2016)
+define(FAT2_PART_OFFSET, 2048)
+define(FAT2_PART_COUNT, 2016)
+define(FAT3_PART_OFFSET, 4096)
+define(FAT3_PART_COUNT, 2016)
+define(FAT4_PART_OFFSET, 6144)
+define(FAT4_PART_COUNT, 2016)
+define(FAT5_PART_OFFSET, 8192)
+define(FAT5_PART_COUNT, 2016)
+
+file-resource file1.txt { contents = "1" }
+file-resource file2.txt { contents = "22" }
+file-resource file3.txt { contents = "333" }
+file-resource file4.txt { contents = "4444" }
+file-resource file5.txt { contents = "55555" }
+file-resource file6.txt { contents = "666666" }
+file-resource file7.txt { contents = "7777777" }
+file-resource file8.txt { contents = "88888888" }
+file-resource file9.txt { contents = "999999999" }
+file-resource file10.txt { contents = "aaaaaaaaaa" }
+
+task complete {
+	on-init {
+                fat_mkfs(\${FAT1_PART_OFFSET}, \${FAT1_PART_COUNT})
+                fat_mkfs(\${FAT2_PART_OFFSET}, \${FAT2_PART_COUNT})
+                fat_mkfs(\${FAT3_PART_OFFSET}, \${FAT3_PART_COUNT})
+                fat_mkfs(\${FAT4_PART_OFFSET}, \${FAT4_PART_COUNT})
+                fat_mkfs(\${FAT5_PART_OFFSET}, \${FAT5_PART_COUNT})
+        }
+        on-resource file1.txt { fat_write(\${FAT1_PART_OFFSET}, "1.txt") }
+        on-resource file2.txt { fat_write(\${FAT2_PART_OFFSET}, "2.txt") }
+        on-resource file3.txt { fat_write(\${FAT3_PART_OFFSET}, "3.txt") }
+        on-resource file4.txt { fat_write(\${FAT4_PART_OFFSET}, "4.txt") }
+        on-resource file5.txt { fat_write(\${FAT5_PART_OFFSET}, "5.txt") }
+        on-resource file6.txt { fat_write(\${FAT4_PART_OFFSET}, "6.txt") }
+        on-resource file7.txt { fat_write(\${FAT3_PART_OFFSET}, "7.txt") }
+        on-resource file8.txt { fat_write(\${FAT2_PART_OFFSET}, "8.txt") }
+        on-resource file9.txt { fat_write(\${FAT1_PART_OFFSET}, "9.txt") }
+        on-resource file10.txt { fat_write(\${FAT5_PART_OFFSET}, "10.txt") }
+	on-finish {
+                fat_setlabel(\${FAT1_PART_OFFSET}, "11111111")
+                fat_setlabel(\${FAT2_PART_OFFSET}, "22222222")
+                fat_setlabel(\${FAT3_PART_OFFSET}, "33333333")
+                fat_setlabel(\${FAT4_PART_OFFSET}, "44444444")
+                fat_setlabel(\${FAT5_PART_OFFSET}, "55555555")
+        }
+}
+EOF
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+
+EXPECTED_OUTPUT=$WORK/expected.out
+ACTUAL_OUTPUT=$WORK/actual.out
+
+cat >$EXPECTED_OUTPUT.1 << EOF
+ Volume in drive : is 11111111
+ Volume Serial Number is 0021-07E0
+Directory for ::/
+
+1        txt         1 1980-01-01   0:00
+9        txt         9 1980-01-01   0:00
+        2 files                  10 bytes
+                          1 008 128 bytes free
+
+EOF
+cat >$EXPECTED_OUTPUT.2 << EOF
+ Volume in drive : is 22222222
+ Volume Serial Number is 0021-07E0
+Directory for ::/
+
+2        txt         2 1980-01-01   0:00
+8        txt         8 1980-01-01   0:00
+        2 files                  10 bytes
+                          1 008 128 bytes free
+
+EOF
+cat >$EXPECTED_OUTPUT.3 << EOF
+ Volume in drive : is 33333333
+ Volume Serial Number is 0021-07E0
+Directory for ::/
+
+3        txt         3 1980-01-01   0:00
+7        txt         7 1980-01-01   0:00
+        2 files                  10 bytes
+                          1 008 128 bytes free
+
+EOF
+cat >$EXPECTED_OUTPUT.4 << EOF
+ Volume in drive : is 44444444
+ Volume Serial Number is 0021-07E0
+Directory for ::/
+
+4        txt         4 1980-01-01   0:00
+6        txt         6 1980-01-01   0:00
+        2 files                  10 bytes
+                          1 008 128 bytes free
+
+EOF
+cat >$EXPECTED_OUTPUT.5 << EOF
+ Volume in drive : is 55555555
+ Volume Serial Number is 0021-07E0
+Directory for ::/
+
+5        txt         5 1980-01-01   0:00
+10       txt        10 1980-01-01   0:00
+        2 files                  15 bytes
+                          1 008 128 bytes free
+
+EOF
+
+# Check that all file systems look right
+LC_ALL= mdir -i $WORK/fwup.img@@0 > $ACTUAL_OUTPUT.1
+LC_ALL= mdir -i $WORK/fwup.img@@1048576 > $ACTUAL_OUTPUT.2
+LC_ALL= mdir -i $WORK/fwup.img@@2097152 > $ACTUAL_OUTPUT.3
+LC_ALL= mdir -i $WORK/fwup.img@@3145728 > $ACTUAL_OUTPUT.4
+LC_ALL= mdir -i $WORK/fwup.img@@4194304 > $ACTUAL_OUTPUT.5
+
+diff -w $EXPECTED_OUTPUT.1 $ACTUAL_OUTPUT.1
+diff -w $EXPECTED_OUTPUT.2 $ACTUAL_OUTPUT.2
+diff -w $EXPECTED_OUTPUT.3 $ACTUAL_OUTPUT.3
+diff -w $EXPECTED_OUTPUT.4 $ACTUAL_OUTPUT.4
+diff -w $EXPECTED_OUTPUT.5 $ACTUAL_OUTPUT.5
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/204_fat_cp_cross_partition.test
+++ b/tests/204_fat_cp_cross_partition.test
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+#
+# Test copying files between FAT file systems
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+define(BOOT_A_PART_OFFSET, 2048)
+define(BOOT_A_PART_COUNT, 2016)
+define(BOOT_B_PART_OFFSET, 4096)
+define(BOOT_B_PART_COUNT, 2016)
+
+file-resource 1K.bin {
+	host-path = "${TESTFILE_1K}"
+}
+
+mbr mbr-a {
+    partition 0 {
+        block-offset = \${BOOT_A_PART_OFFSET}
+        block-count = \${BOOT_A_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = \${BOOT_B_PART_OFFSET}
+        block-count = \${BOOT_B_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+}
+task complete {
+	on-init {
+                mbr_write(mbr-a)
+                fat_mkfs(\${BOOT_A_PART_OFFSET}, \${BOOT_A_PART_COUNT})
+                fat_mkfs(\${BOOT_B_PART_OFFSET}, \${BOOT_B_PART_COUNT})
+        }
+        on-resource 1K.bin {
+                fat_write(\${BOOT_A_PART_OFFSET}, "1.bin")
+        }
+        on-finish {
+                # copy between partitions
+                fat_cp(\${BOOT_A_PART_OFFSET}, "1.bin", \${BOOT_B_PART_OFFSET}, "2.bin")
+                fat_cp(\${BOOT_B_PART_OFFSET}, "2.bin", \${BOOT_A_PART_OFFSET}, "3.bin")
+                fat_cp(\${BOOT_A_PART_OFFSET}, "3.bin", \${BOOT_B_PART_OFFSET}, "4.bin")
+                fat_cp(\${BOOT_B_PART_OFFSET}, "4.bin", \${BOOT_A_PART_OFFSET}, "5.bin")
+                fat_cp(\${BOOT_A_PART_OFFSET}, "5.bin", \${BOOT_B_PART_OFFSET}, "6.bin")
+                fat_cp(\${BOOT_B_PART_OFFSET}, "6.bin", \${BOOT_A_PART_OFFSET}, "7.bin")
+
+                # test copying over an existing file
+                fat_cp(\${BOOT_A_PART_OFFSET}, "1.bin", \${BOOT_A_PART_OFFSET}, "3.bin")
+        }
+}
+EOF
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+
+EXPECTED_OUTPUT=$WORK/expected.out
+ACTUAL_OUTPUT=$WORK/actual.out
+
+cat >$EXPECTED_OUTPUT << EOF
+ Volume in drive : has no label
+ Volume Serial Number is 0021-07E0
+Directory for ::/
+
+1        bin      1024 1980-01-01   0:00
+3        bin      1024 1980-01-01   0:00
+5        bin      1024 1980-01-01   0:00
+7        bin      1024 1980-01-01   0:00
+        4 files               4 096 bytes
+                          1 005 056 bytes free
+
+EOF
+
+# Check that the directory looks right
+LC_ALL= MTOOLS_SKIP_CHECK=1 mdir -i $WORK/fwup.img@@1048576 > $ACTUAL_OUTPUT
+diff -w $EXPECTED_OUTPUT $ACTUAL_OUTPUT
+
+# Check the contents of the file
+for i in 1 3 5 7; do
+    mcopy -n -i $WORK/fwup.img@@1048576 ::/${i}.bin $WORK/actual.1K.bin
+    diff $TESTFILE_1K $WORK/actual.1K.bin
+done
+for i in 2 4 6; do
+    mcopy -n -i $WORK/fwup.img@@2097152 ::/${i}.bin $WORK/actual.1K.bin
+    diff $TESTFILE_1K $WORK/actual.1K.bin
+done
+
+# Check the FAT file format using fsck
+dd if=$WORK/fwup.img skip=2048 count=2048 of=$WORK/vfat.img
+$FSCK_FAT $WORK/vfat.img
+
+dd if=$WORK/fwup.img skip=4096 count=2048 of=$WORK/vfat2.img
+$FSCK_FAT $WORK/vfat2.img
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -203,6 +203,7 @@ TESTS = 001_simple_fw.test \
 	200_uboot_redundant_255.test \
 	201_sign_delta_upgrade2.test \
 	202_fat_rm_missing_path.test \
-	203_multi_fat.test
+	203_multi_fat.test \
+	204_fat_cp_cross_partition.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -202,6 +202,7 @@ TESTS = 001_simple_fw.test \
 	199_partial_read.test \
 	200_uboot_redundant_255.test \
 	201_sign_delta_upgrade2.test \
-	202_fat_rm_missing_path.test
+	202_fat_rm_missing_path.test \
+	203_multi_fat.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This has two commits. The first is to enable multiple FAT partitions being
"mounted" at once. The second adds the 4-arg version of fat_cp to copy across
two partitions.

The motivation for this is to support a Raspberry Pi use case where the
bootloader needed to be copyied to two FAT partitions.

- **Reduce thrashing when writing multiple FAT filesystems**
- **Extend fat_cp to copy between FAT filesystems**
