### PR TITLE
Collect MBR table information in one struct

### DIFF
--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -54,11 +54,11 @@ static bool deprecated_task_is_applicable(cfg_t *task, struct block_cache *outpu
         if (block_cache_pread(output, buffer, FWUP_BLOCK_SIZE, 0) < 0)
             return false;
 
-        struct mbr_partition partitions[4];
-        if (mbr_decode(buffer, partitions) < 0)
+        struct mbr_table table;
+        if (mbr_decode(buffer, &table) < 0)
             return false;
 
-        if (partitions[1].block_offset != (uint32_t) part1_offset)
+        if (table.partitions[1].block_offset != (uint32_t) part1_offset)
             return false;
     }
 

--- a/src/mbr.h
+++ b/src/mbr.h
@@ -21,12 +21,18 @@
 #include <stdint.h>
 #include <confuse.h>
 
+#define MBR_MAX_PRIMARY_PARTITIONS 4
+
 struct mbr_partition {
     bool boot_flag;     // true to mark as boot partition
     bool expand_flag;   // true to indicate that fwup can grow this partition
     int partition_type; // partition type (e.g., 0=unused, 0x83=Linux, 0x01=FAT12, 0x04=FAT16, 0x0c=FAT32, etc.
     uint32_t block_offset;
     uint32_t block_count;
+};
+
+struct mbr_table {
+    struct mbr_partition partitions[MBR_MAX_PRIMARY_PARTITIONS];
 };
 
 struct osii {
@@ -53,6 +59,6 @@ struct osip_header {
 
 int mbr_verify_cfg(cfg_t *cfg);
 int mbr_create_cfg(cfg_t *cfg, uint32_t num_blocks, uint8_t output[512]);
-int mbr_decode(const uint8_t input[512], struct mbr_partition partitions[4]);
+int mbr_decode(const uint8_t input[512], struct mbr_table *table);
 
 #endif // MBR_H

--- a/src/requirement.c
+++ b/src/requirement.c
@@ -157,8 +157,8 @@ int require_partition_offset_validate(struct fun_context *fctx)
         ERR_RETURN("require-partition-offset requires a partition number and a block offset");
 
     int partition = strtol(fctx->argv[1], NULL, 0);
-    if (partition < 0 || partition > 3)
-        ERR_RETURN("require-partition-offset requires the partition number to be between 0, 1, 2, or 3");
+    if (partition < 0 || partition >= MBR_MAX_PRIMARY_PARTITIONS)
+        ERR_RETURN("require-partition-offset requires the partition number to be 0-3");
 
     CHECK_ARG_UINT64(fctx->argv[2], "require-partition-offset requires a non-negative integer block offset");
 
@@ -176,11 +176,11 @@ int require_partition_offset_requirement_met(struct fun_context *fctx)
     if (block_cache_pread(fctx->output, buffer, FWUP_BLOCK_SIZE, 0) < 0)
         return -1;
 
-    struct mbr_partition partitions[4];
-    if (mbr_decode(buffer, partitions) < 0)
+    struct mbr_table table;
+    if (mbr_decode(buffer, &table) < 0)
         return -1;
 
-    if (partitions[partition].block_offset != block_offset)
+    if (table.partitions[partition].block_offset != block_offset)
         return -1;
     else
         return 0;


### PR DESCRIPTION
This cleans up all of the magic number 4s everywhere, but the main goal
is to be a step in the direction of MBR extended partition support.
