### PR TITLE
Add reboot-param function

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@ path_write(destination_path)            | 0.16.0 | Write a resource to a path on
 pipe_write(command)                     | 0.16.0 | Pipe a resource through a command on the host. Requires the `--unsafe` flag
 raw_memset(block_offset, block_count, value) | 0.10.0 | Write the specified byte value repeatedly for the specified blocks
 raw_write(block_offset, options)        | 0.1.0 | Write the resource to the specified block offset. Options include `cipher` and `secret`.
+reboot_param(args)                      | 1.12.0 | A string that will enqueued to the reboot command if supported
 trim(block_offset, count)               | 0.15.0 | Discard any data previously written to the range. TRIM requests are issued to the device if --enable-trim is passed to fwup.
 uboot_clearenv(my_uboot_env)            | 0.10.0 | Initialize a clean, variable free U-boot environment
 uboot_recover(my_uboot_env)             | 0.15.0 | If the U-Boot environment is corrupt, reinitialize it. If not, then do nothing
@@ -987,6 +988,26 @@ is to write them to an unused location first and then switch over at the last
 possible minute. This is desirable to do anyway, since this strategy also
 provides some protection against the user disconnecting power midway through
 the firmware update.
+
+# Reboot parameters
+
+The Linux reboot syscall takes an argument when using the
+`LINUX_REBOOT_CMD_RESTART2` command.  This is not the shutdown timeout. It's a
+free text string passed to the Linux kernel.  It's use is device and
+driver-specific. The Raspberry Pi uses it for its TRYBOOT feature. Fwup allows
+configurations to set the reboot parameters via the `reboot_param` function:
+
+```conf
+reboot_param("0 tryboot")
+```
+
+Even though `fwup` doesn't reboot the system, it can influence the parameter
+passed to the kernel due to the simplistic way this parameter is passed to the
+`init` process (PID 1).  Systemd, for example, reads the
+`/run/systemd/reboot-param` file when `init` initiates the reboot.  Erlinit with
+Nerves uses the file `/run/reboot-param`. Fwup will automatically detect Systemd
+and write the right file. The `--reboot-param-path` commandline argument can be
+used to force a path.
 
 # Integration with applications
 

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -528,7 +528,8 @@ static cfg_opt_t uboot_environment_opts[] = {
     CFG_FUNC("info", CB), \
     CFG_FUNC("path_write", CB), \
     CFG_FUNC("pipe_write", CB), \
-    CFG_FUNC("execute", CB)
+    CFG_FUNC("execute", CB), \
+    CFG_FUNC("reboot_param", CB)
 
 static cfg_opt_t task_on_init_opts[] = {
     CFG_ON_EVENT_FUNCTIONS(cb_on_init_func),

--- a/src/functions.h
+++ b/src/functions.h
@@ -68,6 +68,9 @@ struct fun_context {
     size_t xd_source_count;
     const char *xd_source_path;
 
+    // Reboot parameters
+    const char *reboot_param_path;
+
     void *cookie;
 };
 

--- a/src/fwup_apply.h
+++ b/src/fwup_apply.h
@@ -21,14 +21,19 @@
 
 struct fwup_progress;
 
+struct fwup_apply_options {
+    unsigned char *const*public_keys;
+    bool enable_trim;
+    bool verify_writes;
+    bool minimize_writes;
+    const char *reboot_param_path;
+};
+
 int fwup_apply(const char *fw_filename,
-               const char *task,
+               const char *task_prefix,
                int output_fd,
                off_t end_offset,
                struct fwup_progress *progress,
-               unsigned char *const* public_keys,
-               bool enable_trim,
-               bool verify_writes,
-               bool minimize_writes);
+               const struct fwup_apply_options *options);
 
 #endif // FWUP_APPLY_H

--- a/tests/209_reboot_param.test
+++ b/tests/209_reboot_param.test
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+#
+# Test the reboot-param command
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+task complete {
+	on-init { reboot_param("0 tryboot") }
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Check that applying the firmware does the expected thing
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete --reboot-param-path "$WORK/reboot-param"
+
+# Check that the reboot-param file has the expected contents
+if [ "$(cat $WORK/reboot-param)" != "0 tryboot" ]; then
+	echo "reboot-param file has unexpected contents"
+	exit 1
+fi
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -208,6 +208,7 @@ TESTS = 001_simple_fw.test \
 	205_mbr_ebr.test \
 	206_mbr_ebr_missing_partition.test \
 	207_mbr_ebr_overlapping_records.test \
-	208_mbr_ebr_overlapping_parts.test
+	208_mbr_ebr_overlapping_parts.test \
+	209_reboot_param.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This function influences the reboot call that's normally run after an
update. This is useful for Raspberry Pi devices that need to pass `"0
tryboot"` to reboot on updates.
