### PR TITLE
Fix raw_memset max value

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -457,7 +457,7 @@ int raw_memset_validate(struct fun_context *fctx)
         ERR_RETURN("raw_memset requires a block offset, count, and value");
 
     CHECK_ARG_UINT64(fctx->argv[1], "raw_memset requires a non-negative integer block offset");
-    CHECK_ARG_UINT64_RANGE(fctx->argv[2], 1, INT32_MAX / FWUP_BLOCK_SIZE, "raw_memset requires a positive integer block count");
+    CHECK_ARG_UINT64_RANGE(fctx->argv[2], 1, INT64_MAX / FWUP_BLOCK_SIZE, "raw_memset requires a positive integer block count");
 
     int value = strtol(fctx->argv[3], NULL, 0);
     if (value < 0 || value > 255)


### PR DESCRIPTION
Hi,

I have a case where the value of 'fctx->argv[2]' is "19272772" which is greater than: `INT32_MAX / FWUP_BLOCK_SIZE`.

Well, my test images are big :)

So, changing INT32_MAX to INT64_MAX solves the case.

Does it make sense ?