### PR TITLE
Support the use of device mapper for root filesystem mounts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,8 @@ AC_DEFUN([CHECK_HOST_SUPPORT_FOR_SHIMS], [
             eval "$1=yes"
             ;;
         aarch64-apple-darwin*)
-            eval "$1=yes"
+            # This works fine on Sequoia, but not on earlier versions. Disable for now.
+            eval "$1=no"
             ;;
         *)
             eval "$1=no"

--- a/tests/210_new_require_path.test
+++ b/tests/210_new_require_path.test
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+#
+# Tests that the "require-path-on-device" feature works. This allows one to
+# update firmware images based on where the filesystem is mounted.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+$HAS_MOUNT_SHIM || exit 77
+
+cat >$CONFIG <<EOF
+task test.correct {
+    require-path-on-device("/", "/dev/rootdisk0p1")
+    on-init { info("correct") }
+}
+task test.fail {
+    on-init { error("something else!") }
+}
+EOF
+cat >$WORK/expected_output.txt <<EOF
+fwup: correct
+EOF
+
+# Create the firmware file the normal way
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Use the mount shim instead of the write shim
+LD_PRELOAD="$MOUNT_LD_PRELOAD" DYLD_INSERT_LIBRARIES="$MOUNT_DYLD_INSERT_LIBRARIES" $FWUP_APPLY -a -q -d $IMGFILE -i $FWFILE -t test > $WORK/actual_output.txt
+diff -w $WORK/expected_output.txt $WORK/actual_output.txt
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/211_new_require_path_dm.test
+++ b/tests/211_new_require_path_dm.test
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+#
+# Tests that the "require-path-on-device" feature can traverse through
+# device mapper mounts.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+$HAS_MOUNT_SHIM || exit 77
+
+if [ "$HOST_OS" != "Linux" ]; then
+    echo "Skipping since device mapper logic only on Linux-specific fwup code."
+    exit 77
+fi
+
+cat >$CONFIG <<EOF
+task test.correct {
+    require-path-on-device("/boot", "/dev/mmcblk0p2")
+    on-init { info("correct") }
+}
+task test.fail {
+    on-init { error("something else!") }
+}
+EOF
+cat >$WORK/expected_output.txt <<EOF
+fwup: correct
+EOF
+
+# Create the firmware file the normal way
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Set up some fake /sys/dev/block directories similar to device mapper
+mkdir -p $WORK/sys/dev/block/254:0/slaves/mmcblk0p1 # Fake entry to test scanning
+mkdir -p $WORK/sys/dev/block/254:0/slaves/mmcblk0p2
+mkdir -p $WORK/sys/dev/block/254:0/slaves/mmcblk0p3 # Fake entry to test scanning
+echo "1:1" > $WORK/sys/dev/block/254:0/slaves/mmcblk0p1/dev
+echo "179:2" > $WORK/sys/dev/block/254:0/slaves/mmcblk0p2/dev
+echo "1:1" > $WORK/sys/dev/block/254:0/slaves/mmcblk0p3/dev
+
+# Use the mount shim instead of the write shim
+LD_PRELOAD="$MOUNT_LD_PRELOAD" DYLD_INSERT_LIBRARIES="$MOUNT_DYLD_INSERT_LIBRARIES" $FWUP_APPLY -a -q -d $IMGFILE -i $FWFILE -t test > $WORK/actual_output.txt
+diff -w $WORK/expected_output.txt $WORK/actual_output.txt
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -209,6 +209,8 @@ TESTS = 001_simple_fw.test \
 	206_mbr_ebr_missing_partition.test \
 	207_mbr_ebr_overlapping_records.test \
 	208_mbr_ebr_overlapping_parts.test \
-	209_reboot_param.test
+	209_reboot_param.test \
+	210_new_require_path.test \
+	211_new_require_path_dm.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -140,7 +140,19 @@ else
     export HAS_WRITE_SHIM=false
 fi
 
-WORK=$TESTS_DIR/work-$(basename "$0")
+# The mount simulator only runs only runs on a subset of
+# platforms. Let autoconf figure out which ones.
+MOUNT_SHIM="$TESTS_DIR/fixture/.libs/libmount_shim.$SO_EXT"
+if [ -e "$MOUNT_SHIM" ]; then
+    export HAS_MOUNT_SHIM=true
+    export MOUNT_LD_PRELOAD="$MOUNT_SHIM"
+    export MOUNT_DYLD_INSERT_LIBRARIES="$MOUNT_SHIM"
+else
+    export HAS_MOUNT_SHIM=false
+fi
+
+# Export WORK for the shims to use if needed
+export WORK=$TESTS_DIR/work-$(basename "$0")
 RESULTS=$WORK/results
 
 CONFIG=$WORK/fwup.conf

--- a/tests/fixture/.gitignore
+++ b/tests/fixture/.gitignore
@@ -2,3 +2,4 @@
 /verify-syscalls
 /.libs
 /libwrite_shim*
+/libmount_shim*

--- a/tests/fixture/Makefile.am
+++ b/tests/fixture/Makefile.am
@@ -11,11 +11,15 @@ verify_syscalls_SOURCES=verify-syscalls.c
 endif
 
 if HAS_WRITE_SHIM
-check_LTLIBRARIES = libwrite_shim.la
+check_LTLIBRARIES = libwrite_shim.la libmount_shim.la
 libwrite_shim_la_SOURCES = write_shim.c
 
 # The "-rpath /nowhere" is the trick to getting libtool to create a shared library for
 # "check" LTLIBRARIES.
 libwrite_shim_la_LDFLAGS = ${AM_LDFLAGS} -ldl -dynamiclib -avoid-version -shared -rpath /nowhere
 libwrite_shim_la_CFLAGS = ${AM_CFLAGS}
+
+libmount_shim_la_SOURCES = mount_shim.c
+libmount_shim_la_LDFLAGS = ${AM_LDFLAGS} -ldl -dynamiclib -avoid-version -shared -rpath /nowhere
+libmount_shim_la_CFLAGS = ${AM_CFLAGS} -D_FILE_OFFSET_BITS=64
 endif

--- a/tests/fixture/mount_shim.c
+++ b/tests/fixture/mount_shim.c
@@ -1,0 +1,222 @@
+// This shim simulates various filesystem mounting scenarios for testing purposes.
+//
+// It intercepts stat() calls to set device numbers and redirects calls going to
+// /sys to under the $WORK directory.
+
+#define _GNU_SOURCE // for RTLD_NEXT
+#include <dirent.h>
+#include <dlfcn.h>
+#include <err.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "config.h"
+
+#ifndef __APPLE__
+#define ORIGINAL(name) original_##name
+#define REPLACEMENT(name) name
+#define OVERRIDE(ret, name, args) \
+    static ret (*original_##name) args; \
+    __attribute__((constructor)) void init_##name() { ORIGINAL(name) = dlsym(RTLD_NEXT, #name); } \
+    ret REPLACEMENT(name) args
+
+#define REPLACE(ret, name, args) \
+    ret REPLACEMENT(name) args
+#else
+#define ORIGINAL(name) name
+#define REPLACEMENT(name) new_##name
+#define OVERRIDE(ret, name, args) \
+    ret REPLACEMENT(name) args; \
+    __attribute__((used)) static struct { const void *original; const void *replacement; } _interpose_##name \
+    __attribute__ ((section ("__DATA,__interpose"))) = { (const void*)(unsigned long)&REPLACEMENT(name), (const void*)(unsigned long)&ORIGINAL(name) }; \
+    ret REPLACEMENT(name) args
+
+#define REPLACE(ret, name, args) OVERRIDE(ret, name, args)
+#endif
+
+#ifdef __APPLE__
+#define OVERRIDE_STAT 1
+#else
+#if __GLIBC_PREREQ(2, 33)
+#define OVERRIDE_STAT 1
+#else
+#define OVERRIDE_XSTAT 1
+#endif
+#endif
+
+static const char *work = NULL;
+
+__attribute__((constructor)) void mount_shim_init()
+{
+    work = getenv("WORK");
+    if (work == NULL)
+        work = ".";
+}
+
+static void fixup_path(const char *input, char *output)
+{
+    // If looking under /sys, move to work directory for fake files.
+    if (strncmp(input, "/sys/", 5) == 0)
+        sprintf(output, "%s%s", work, input);
+    else
+        strcpy(output, input);
+}
+
+#ifdef __USE_LARGEFILE64
+OVERRIDE(FILE *, fopen64, (const char *pathname, const char *mode))
+{
+    char new_path[PATH_MAX];
+    fixup_path(pathname, new_path);
+    return ORIGINAL(fopen64)(new_path, mode);
+}
+#else
+OVERRIDE(FILE *, fopen, (const char *pathname, const char *mode))
+{
+    char new_path[PATH_MAX];
+    fixup_path(pathname, new_path);
+    return ORIGINAL(fopen)(new_path, mode);
+}
+#endif
+
+#ifdef __USE_LARGEFILE64
+OVERRIDE(int, open64, (const char *pathname, int flags, ...))
+{
+    int mode;
+
+    va_list ap;
+    va_start(ap, flags);
+    if (flags & O_CREAT)
+        mode = va_arg(ap, int);
+    else
+        mode = 0;
+    va_end(ap);
+
+    char new_path[PATH_MAX];
+    fixup_path(pathname, new_path);
+
+    return ORIGINAL(open64)(new_path, flags, mode);
+}
+#else
+OVERRIDE(int, open, (const char *pathname, int flags, ...))
+{
+    int mode;
+
+    va_list ap;
+    va_start(ap, flags);
+    if (flags & O_CREAT)
+        mode = va_arg(ap, int);
+    else
+        mode = 0;
+    va_end(ap);
+
+    char new_path[PATH_MAX];
+    fixup_path(pathname, new_path);
+
+    return ORIGINAL(open)(new_path, flags, mode);
+}
+#endif
+
+#ifdef __USE_LARGEFILE64
+OVERRIDE(int, scandir64, (const char *dirp, struct dirent64 ***namelist, int (*filter)(const struct dirent64 *), int (*compar)(const struct dirent64 **, const struct dirent64 **)))
+{
+    char new_path[PATH_MAX];
+    fixup_path(dirp, new_path);
+    return ORIGINAL(scandir64)(new_path, namelist, filter, compar);
+}
+#else
+OVERRIDE(int, scandir, (const char *dirp, struct dirent ***namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **)))
+{
+    char new_path[PATH_MAX];
+    fixup_path(dirp, new_path);
+
+    return ORIGINAL(scandir)(new_path, namelist, filter, compar);
+}
+#endif
+
+static int stat_impl(const char *pathname, mode_t *mode, dev_t *dev, dev_t *rdev)
+{
+    if (strcmp(pathname, "/") == 0) {
+        *dev = 0xb301;
+        *mode = S_IFDIR;
+        return 0;
+    } else if (strcmp(pathname, "/boot") == 0) {
+        *dev = 0xfe00;
+        *mode = S_IFDIR;
+        return 0;
+    } else if (strcmp(pathname, "/dev/mmcblk0") == 0) {
+        *rdev = 0xb300;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/mmcblk0p1") == 0) {
+        *rdev = 0xb301;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/mmcblk0p2") == 0) {
+        *rdev = 0xb302;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/mmcblk0p3") == 0) {
+        *rdev = 0xb303;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/mmcblk0p4") == 0) {
+        *rdev = 0xb304;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/rootdisk0p1") == 0) {
+        *rdev = 0xb301;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/dm-0") == 0) {
+        *rdev = 0xfe00;
+        *mode = S_IFBLK;
+        return 0;
+    } else if (strcmp(pathname, "/dev/dm-1") == 0) {
+        *rdev = 0xfe01;
+        *mode = S_IFBLK;
+        return 0;
+     } else {
+        return -1;
+    }
+}
+
+#ifdef OVERRIDE_STAT
+#ifdef __USE_LARGEFILE64
+OVERRIDE(int, stat64, (const char *pathname, struct stat64 *st))
+{
+    memset(st, 0, sizeof(*st));
+    if (stat_impl(pathname, &st->st_mode, &st->st_dev, &st->st_rdev) == 0)
+        return 0;
+    else
+        return ORIGINAL(stat64)(pathname, st);
+}
+#else
+OVERRIDE(int, stat, (const char *pathname, struct stat *st))
+{
+    memset(st, 0, sizeof(*st));
+    if (stat_impl(pathname, &st->st_mode, &st->st_dev, &st->st_rdev) == 0)
+        return 0;
+    else
+        return ORIGINAL(stat)(pathname, st);
+}
+#endif
+#endif
+#ifdef OVERRIDE_XSTAT
+#ifdef __USE_LARGEFILE64
+OVERRIDE(int, __xstat64, (int ver, const char *pathname, struct stat64 *st))
+{
+    memset(st, 0, sizeof(*st));
+    if (stat_impl(pathname, &st->st_mode, &st->st_dev, &st->st_rdev) == 0)
+        return 0;
+    else
+        return ORIGINAL(__xstat64)(ver, pathname, st);
+}
+#endif
+#endif


### PR DESCRIPTION
This makes it possible to detect the physical block device that the root
filesystem uses even if Linux's device mapper is being used for
encrypted partitions or overlays or anything else.
