### PR TITLE
Change docs for streaming WN message to indicate info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,7 +1070,7 @@ Type           | 2 byte value | Description
 ---------------|--------------|------------
 Success        | "OK"         | The command was executed successfully. The payload is a 2 bytes result code (currently 0 for success) followed by an optional textual message.
 Error          | "ER"         | A failure occurred. The payload is a 2 byte error code (future use) followed by a textual error message.
-Warning        | "WN"         | A warning occurred. The payload is a 2 byte error code (future use) followed by a textual error message.
+Info           | "WN"         | Output from info() calls and rare non-fatal fwup warnings. The payload is a 2 byte code (future use) followed by a textual message.
 Progress       | "PR"         | The next two bytes are the progress (0-100) as a big endian integer.
 
 A related option is `--exit-handshake`. This option was specifically implemented

--- a/src/util.c
+++ b/src/util.c
@@ -435,7 +435,7 @@ void fwup_warnx(const char *format, ...)
         ssvprintf(&s, format, ap);
         ssappend(&s, "\n");
     }
-    fwup_output(FRAMING_TYPE_WARNING, 0, s.str);
+    fwup_output(FRAMING_TYPE_INFO, 0, s.str);
     free(s.str);
 
     va_end(ap);

--- a/src/util.h
+++ b/src/util.h
@@ -138,7 +138,7 @@ char* strptime(const char *buf, const char *fmt, struct tm *tm);
 
 #define FRAMING_TYPE_SUCCESS  "OK"
 #define FRAMING_TYPE_ERROR    "ER"
-#define FRAMING_TYPE_WARNING  "WN"
+#define FRAMING_TYPE_INFO     "WN"
 #define FRAMING_TYPE_PROGRESS "PR"
 
 // Send output to the terminal based on the framing options


### PR DESCRIPTION
The use of this message for actual warnings is so rare that saying it is
a warning is misleading. This message comes from calls to info() in
fwup.conf files nearly all of the time.

This changes the docs, but not the letters used for the message so
there's no concern about backwards compatibility.
