### PR TITLE
Support soft limits for regular files

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -95,6 +95,7 @@ struct block_cache {
 
     // If end_offset > 0, then it's the last allowed offset
     off_t end_offset;
+    bool is_soft_end_offset; // true if it's ok to write past end_offset (e.g., regular file)
 
     // Asynchronous writes
 #if USE_PTHREADS
@@ -109,7 +110,7 @@ struct block_cache {
 #endif
 };
 
-int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool enable_trim, bool verify_writes, bool minimize_writes);
+int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool is_soft_end_offset, bool enable_trim, bool verify_writes, bool minimize_writes);
 int block_cache_trim(struct block_cache *bc, off_t offset, off_t count, bool hwtrim);
 int block_cache_trim_after(struct block_cache *bc, off_t offset, bool hwtrim);
 int block_cache_pwrite(struct block_cache *bc, const void *buf, size_t count, off_t offset, bool streamed);

--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -504,7 +504,6 @@ cleanup:
 int fwup_apply(const char *fw_filename,
                const char *task_prefix,
                int output_fd,
-               off_t end_offset,
                struct fwup_progress *progress,
                const struct fwup_apply_options *options)
 {
@@ -556,7 +555,7 @@ int fwup_apply(const char *fw_filename,
     // Initialize the output. Nothing should have been written before now
     // and waiting to initialize the output until now forces the point.
     fctx.output = (struct block_cache *) malloc(sizeof(struct block_cache));
-    OK_OR_CLEANUP(block_cache_init(fctx.output, output_fd, end_offset, options->enable_trim, options->verify_writes,options->minimize_writes));
+    OK_OR_CLEANUP(block_cache_init(fctx.output, output_fd, options->end_offset, options->is_soft_end_offset, options->enable_trim, options->verify_writes, options->minimize_writes));
 
     // Go through all of the tasks and find a matcher
     fctx.task = find_task(&fctx, task_prefix);

--- a/src/fwup_apply.h
+++ b/src/fwup_apply.h
@@ -27,12 +27,13 @@ struct fwup_apply_options {
     bool verify_writes;
     bool minimize_writes;
     const char *reboot_param_path;
+    off_t end_offset;
+    bool is_soft_end_offset;
 };
 
 int fwup_apply(const char *fw_filename,
                const char *task_prefix,
                int output_fd,
-               off_t end_offset,
                struct fwup_progress *progress,
                const struct fwup_apply_options *options);
 

--- a/tests/214_expand_afterwards.test
+++ b/tests/214_expand_afterwards.test
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# Test soft limits and growing regular files
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+file-resource test {
+        host-path = "${TESTFILE_1K}"
+}
+
+task step1 {
+	on-resource test { raw_write(0) }
+}
+task step2 {
+	on-resource test { raw_write(512) }
+}
+EOF
+
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t step1
+
+# This will fail if soft limits aren't working since fwup won't grow the file.
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t step2
+
+# The firmware file is equivalent to the following dd call
+# (The conv=sync makes sure that the output is a multiple of 512 bytes)
+cp $TESTFILE_1K $WORK/check.bin
+dd if=$TESTFILE_1K seek=512 of=$WORK/check.bin conv=sync 2>/dev/null
+cmp_bytes 263168 $WORK/check.bin $IMGFILE
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -213,6 +213,7 @@ TESTS = 001_simple_fw.test \
 	210_new_require_path.test \
 	211_new_require_path_dm.test \
 	212_encrypted_delta_upgrade.test \
-	213_encrypted_delta_upgrade_unaligned.test
+	213_encrypted_delta_upgrade_unaligned.test \
+	214_expand_afterwards.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
Regular files worked differently depending on whether fwup was run to
create an image file or to modify an image file. When creating the file,
the fwup instructions could expand it as much as disk space allowed.
However, when modifying the file, fwup limited the max length to the
existing length or whatever was passed on the command line.

This commit adds the concept of a soft limit when modifying existing
files. This soft limit can be bumped when writing, but gets used when
expanding partitions to fill space.

Fixes the cause of the error in #253. The hang won't happen, but the next PR will fix the hang that blocked the error.
